### PR TITLE
Make Client axios instance public, update and add functions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules/
+dist/

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "multinet",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "description": "Multinet client library",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/client.ts
+++ b/src/client.ts
@@ -1,7 +1,7 @@
 import axios, { AxiosInstance } from 'axios';
 
 export class Client {
-  private axios: AxiosInstance;
+  public axios: AxiosInstance;
 
   constructor(baseURL: string) {
     this.axios = axios.create({
@@ -19,10 +19,6 @@ export class Client {
           reject(resp.response);
         });
     });
-  }
-
-  public raw_get(path: string, params: {} = {}): Promise<any> {
-      return this.axios.get(path, { params });
   }
 
   public post(path: string, params: {} = {}, headers: {} = {}): Promise<any> {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 import { Client } from './client';
+import { AxiosPromise } from 'axios';
 
 export interface TableRow {
   _key: string;
@@ -137,6 +138,10 @@ class MultinetAPI {
     return this.client.delete(`/workspaces/${workspace}`);
   }
 
+  public renameWorkspace(workspace: string, name: string): AxiosPromise {
+    return this.client.axios.put(`workspaces/${workspace}/name`, null, { params: { name }});
+  }
+
   public async uploadTable(workspace: string, table: string, options: FileUploadOptionsSpec): Promise<Array<{}>> {
     let text;
     if (typeof options.data === 'string') {
@@ -150,8 +155,8 @@ class MultinetAPI {
     });
   }
 
-  public async downloadTable(workspace: string, table: string): Promise<any> {
-    return await this.client.raw_get(`/workspaces/${workspace}/tables/${table}/download`);
+  public downloadTable(workspace: string, table: string): AxiosPromise {
+    return this.client.axios.get(`/workspaces/${workspace}/tables/${table}/download`);
   }
 
   public deleteTable(workspace: string, table: string): Promise<string> {
@@ -172,8 +177,8 @@ class MultinetAPI {
     return this.client.post(`/workspaces/${workspace}/aql`, query, {'Content-Type': 'text/plain'});
   }
 
-  public async downloadGraph(workspace: string, graph: string): Promise<any> {
-    return await this.client.raw_get(`/workspaces/${workspace}/graphs/${graph}/download`);
+  public downloadGraph(workspace: string, graph: string): AxiosPromise {
+    return this.client.axios.get(`/workspaces/${workspace}/graphs/${graph}/download`);
   }
 }
 


### PR DESCRIPTION
Along with making this change to the `Client` class, it also updates existing functions relevant to this change, as well as adds a new function `renameWorkspace`. 