### PR TITLE
Always send credentials with axios requests

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "multinet",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "description": "Multinet client library",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/client.ts
+++ b/src/client.ts
@@ -6,6 +6,7 @@ export class Client {
   constructor(baseURL: string) {
     this.axios = axios.create({
       baseURL,
+      withCredentials: true,
     });
   }
 


### PR DESCRIPTION
Closes #9 

This is needed in order for client apps (in particular, multinet-client) to properly filter workspaces, etc. based on user permissions/roles.

TODO
- [x] perform a release