### PR TITLE
Expose axios config in `uploadTable` function

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "multinet",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "description": "Multinet client library",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/index.ts
+++ b/src/index.ts
@@ -144,8 +144,13 @@ class MultinetAPI {
     return this.client.axios.put(`workspaces/${workspace}/name`, null, { params: { name } });
   }
 
-  public async uploadTable(workspace: string, table: string, options: FileUploadOptionsSpec): Promise<Array<{}>> {
+  public async uploadTable(
+    workspace: string, table: string, options: FileUploadOptionsSpec, config?: AxiosRequestConfig
+  ): Promise<Array<{}>> {
+    const headers = config ? config.headers : undefined;
+    const params = config ? config.params : undefined;
     const { type, data, key, overwrite } = options;
+
     let text;
 
     if (typeof data === 'string') {
@@ -155,8 +160,10 @@ class MultinetAPI {
     }
 
     return this.client.post(`/${type}/${workspace}/${table}`, text, {
-      headers: { 'Content-Type': 'text/plain' },
+      ...config,
+      headers: { ...headers, 'Content-Type': 'text/plain' },
       params: {
+        ...params,
         key: key || undefined,
         overwrite: overwrite || undefined,
       },


### PR DESCRIPTION
This is to directly address https://github.com/multinet-app/multinet-client/pull/109, but I think in general we should expose an optional `config?: AxiosRequestConfig` variable in all of our api methods. This allows for both what is seen in the mentioned PR, as well as general flexibility and extensibility.

TODO:
- [x] Bump `multinetjs` version
- [x] Perform release