### PR TITLE
Add support for workspace permissions and user search

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "multinet",
-  "version": "0.15.0",
+  "version": "0.16.0",
   "description": "Multinet client library",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/client.ts
+++ b/src/client.ts
@@ -34,6 +34,18 @@ export class Client {
     });
   }
 
+  public put(path: string, data: any = null, params: AxiosRequestConfig = {}): Promise<any> {
+    return new Promise((resolve, reject) => {
+      this.axios.put(path, data, params)
+        .then((resp) => {
+          resolve(resp.data);
+        })
+        .catch((resp) => {
+          reject(resp.response);
+        });
+    });
+  }
+
   public delete(path: string, params: {} = {}): Promise<any> {
     return new Promise((resolve, reject) => {
       this.axios.delete(path, params)

--- a/src/index.ts
+++ b/src/index.ts
@@ -33,12 +33,12 @@ export interface EdgesSpec {
 }
 
 export interface UserSpec {
-  family_name: string
-  given_name: string
-  name: string
-  picture: string
-  email: string
-  sub: string
+  family_name: string;
+  given_name: string;
+  name: string;
+  picture: string;
+  email: string;
+  sub: string;
 }
 
 export interface WorkspacePermissionsSpec {
@@ -122,7 +122,9 @@ class MultinetAPI {
     return this.client.get(`workspaces/${workspace}/permissions`);
   }
 
-  public setWorkspacePermissions(workspace: string, permissions: WorkspacePermissionsSpec): Promise<WorkspacePermissionsSpec> {
+  public setWorkspacePermissions(
+    workspace: string, permissions: WorkspacePermissionsSpec
+  ): Promise<WorkspacePermissionsSpec> {
     if (!workspace) {
       throw new Error('argument "workspace" must not be empty');
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -32,6 +32,24 @@ export interface EdgesSpec {
   edges: Edge[];
 }
 
+export interface UserSpec {
+  family_name: string
+  given_name: string
+  name: string
+  picture: string
+  email: string
+  sub: string
+}
+
+export interface WorkspacePermissionsSpec {
+  owner: UserSpec;
+  maintainers: UserSpec[];
+  writers: UserSpec[];
+  readers: UserSpec[];
+  public: boolean;
+}
+
+
 export type TableType = 'all' | 'node' | 'edge';
 
 export type TableUploadType = 'csv';
@@ -96,12 +114,20 @@ class MultinetAPI {
     return this.client.get('workspaces');
   }
 
-  public workspace(workspace: string): Promise<string> {
+  public getWorkspacePermissions(workspace: string): Promise<WorkspacePermissionsSpec> {
     if (!workspace) {
       throw new Error('argument "workspace" must not be empty');
     }
 
-    return this.client.get(`workspaces/${workspace}`);
+    return this.client.get(`workspaces/${workspace}/permissions`);
+  }
+
+  public setWorkspacePermissions(workspace: string, permissions: WorkspacePermissionsSpec): Promise<WorkspacePermissionsSpec> {
+    if (!workspace) {
+      throw new Error('argument "workspace" must not be empty');
+    }
+
+    return this.client.axios.put(`workspaces/${workspace}/permissions`, permissions);
   }
 
   public tables(workspace: string, options: TablesOptionsSpec = {}): Promise<string[]> {

--- a/src/index.ts
+++ b/src/index.ts
@@ -130,6 +130,10 @@ class MultinetAPI {
     return this.client.axios.put(`workspaces/${workspace}/permissions`, permissions);
   }
 
+  public searchUsers(query: string): Promise<UserSpec[]> {
+    return this.client.get('/user/search', { query });
+  }
+
   public tables(workspace: string, options: TablesOptionsSpec = {}): Promise<string[]> {
     return this.client.get(`workspaces/${workspace}/tables`, options);
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -127,7 +127,7 @@ class MultinetAPI {
       throw new Error('argument "workspace" must not be empty');
     }
 
-    return this.client.axios.put(`workspaces/${workspace}/permissions`, permissions);
+    return this.client.put(`workspaces/${workspace}/permissions`, permissions);
   }
 
   public searchUsers(query: string): Promise<UserSpec[]> {


### PR DESCRIPTION
This PR does several things:

* Add a `put` method on the `Client` class
* Add `UserSpec` and `WorkspacePermissionsSpec` interfaces
* Add `getWorkspacePermissions` and `setWorkspacePermissions` API methods
* Add `searchUsers` API method

This also introduces a breaking change, as the `workspace` API method is replaced by the `getWorkspacePermissions` method. However, I don't believe this function is used anywhere in the client currently.

TODO:

- [x] Bump version for release
- [x] Perform release