### PR TITLE
Move axios request config option into main uploadTable options argument

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -62,6 +62,7 @@ export interface FileUploadOptionsSpec {
   data: string | File;
   key?: string;
   overwrite?: boolean;
+  axiosRequestConfig?: AxiosRequestConfig;
 }
 
 export interface CreateGraphOptionsSpec {
@@ -145,8 +146,9 @@ class MultinetAPI {
   }
 
   public async uploadTable(
-    workspace: string, table: string, options: FileUploadOptionsSpec, config?: AxiosRequestConfig
+    workspace: string, table: string, options: FileUploadOptionsSpec
   ): Promise<Array<{}>> {
+    const config = options.axiosRequestConfig;
     const headers = config ? config.headers : undefined;
     const params = config ? config.params : undefined;
     const { type, data, key, overwrite } = options;


### PR DESCRIPTION
This cleans up the calling sequence for `uploadTable`, enabling the caller to place any axios config values into a special entry in the `options` argument, rather than having to supply it as a separate argument. This makes the calling sequence easier to parse in the code, and makes it explicit what the formerly separate argument is for.

The two calls to `uploadTable` in the multinet-client codebase will benefit from this change.