### PR TITLE
Use `Authorization` header instead of cookie inclusion

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "multinet",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "description": "Multinet client library",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/client.ts
+++ b/src/client.ts
@@ -4,10 +4,15 @@ export class Client {
   public axios: AxiosInstance;
 
   constructor(baseURL: string) {
-    this.axios = axios.create({
-      baseURL,
-      withCredentials: true,
-    });
+    this.axios = axios.create({ baseURL });
+  }
+
+  public setAuthToken(token: string) {
+    this.axios.defaults.headers.common.Authorization = `Bearer ${token}`;
+  }
+
+  public removeAuthToken() {
+    delete this.axios.defaults.headers.common.Authorization;
   }
 
   public get(path: string, params: {} = {}): Promise<any> {

--- a/src/client.ts
+++ b/src/client.ts
@@ -7,14 +7,6 @@ export class Client {
     this.axios = axios.create({ baseURL });
   }
 
-  public setAuthToken(token: string) {
-    this.axios.defaults.headers.common.Authorization = `Bearer ${token}`;
-  }
-
-  public removeAuthToken() {
-    delete this.axios.defaults.headers.common.Authorization;
-  }
-
   public get(path: string, params: {} = {}): Promise<any> {
     return new Promise((resolve, reject) => {
       this.axios.get(path, { params, })

--- a/src/index.ts
+++ b/src/index.ts
@@ -106,8 +106,14 @@ function fileToText(file: File): Promise<string> {
 class MultinetAPI {
   private client: Client;
 
-  constructor(baseURL: string) {
+  constructor(baseURL: string, authToken: string | null = null) {
     this.client = new Client(baseURL);
+
+    if (authToken !== null) {
+      this.client.setAuthToken(authToken);
+    }
+  }
+
   }
 
   public workspaces(): Promise<string[]> {
@@ -238,6 +244,6 @@ class MultinetAPI {
   }
 }
 
-export function multinetApi(baseURL: string): MultinetAPI {
-  return new MultinetAPI(baseURL);
+export function multinetApi(baseURL: string, authToken: string | null = null): MultinetAPI {
+  return new MultinetAPI(baseURL, authToken);
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -110,13 +110,21 @@ class MultinetAPI {
     this.client = new Client(baseURL);
 
     if (authToken !== null) {
-      this.client.setAuthToken(authToken);
+      this.setAuthToken(authToken);
     }
+  }
+
+  public setAuthToken(token: string) {
+    this.client.axios.defaults.headers.common.Authorization = `Bearer ${token}`;
+  }
+
+  public removeAuthToken() {
+    delete this.client.axios.defaults.headers.common.Authorization;
   }
 
   public logout() {
     this.client.get('/user/logout');
-    this.client.removeAuthToken();
+    this.removeAuthToken();
   }
 
   public userInfo(): Promise<UserSpec | null> {

--- a/src/index.ts
+++ b/src/index.ts
@@ -114,6 +114,13 @@ class MultinetAPI {
     }
   }
 
+  public logout() {
+    this.client.get('/user/logout');
+    this.client.removeAuthToken();
+  }
+
+  public userInfo(): Promise<UserSpec | null> {
+    return this.client.get('/user/info');
   }
 
   public workspaces(): Promise<string[]> {


### PR DESCRIPTION
Notable changes:

* ~~Makes `MultinetAPI().client` public~~
* Adds `authToken` argument to `MultinetAPI` constructor
* Adds functions in `Client` for handling auth token
* Adds `userInfo` method to `MultinetAPI`
* Adds `logout` method to `MultinetAPI`