### PR TITLE
Add push-tag-to-release logic to github workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -38,11 +38,11 @@ jobs:
         if: steps.multinetjs-cache.outputs.cache-hit != 'true'
         run: yarn install
 
-      - name: Create a production build
-        run: yarn build
-
       - name: Run linting test
         run: yarn lint
+
+      - name: Create a production build
+        run: yarn build
 
       - name: Get the publishing version number
         id: version-number

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,21 +13,22 @@ on:
       - v[0-9]+.[0-9]+.[0-9]+*
 
 jobs:
-  build-and-test:
-    name: Build and test on Ubuntu - Node 10
+  build:
+    name: Build, lint, and publish
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@master
+      - name: Check out the repository
+        uses: actions/checkout@master
         with:
           fetch-depth: 0
 
-      # Build and test Multinet client app.
-      - uses: actions/setup-node@v1
+      - name: Set up Node environment
+        uses: actions/setup-node@v1
         with:
           node-version: '10.x'
 
-      # Build and test Multinet client library.
-      - uses: actions/cache@v1
+      - name: Restore node_modules cache
+        uses: actions/cache@v1
         id: multinetjs-cache
         with:
           path: /home/runner/work/multinetjs/multinetjs/node_modules
@@ -37,10 +38,13 @@ jobs:
         if: steps.multinetjs-cache.outputs.cache-hit != 'true'
         run: yarn install
 
-      - run: yarn build
-      - run: yarn lint
+      - name: Create a production build
+        run: yarn build
 
-      - name: Get the version number
+      - name: Run linting test
+        run: yarn lint
+
+      - name: Get the publishing version number
         id: version-number
         run: echo "::set-output name=version::$(git describe --tags | tail -c +2)"
         if: startsWith(github.ref, 'refs/tags/')

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,12 +9,17 @@ on:
     branches:
       - master
 
+    tags:
+      - v[0-9]+.[0-9]+.[0-9]+*
+
 jobs:
   build-and-test:
     name: Build and test on Ubuntu - Node 10
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@master
+        with:
+          fetch-depth: 0
 
       # Build and test Multinet client app.
       - uses: actions/setup-node@v1
@@ -34,4 +39,14 @@ jobs:
 
       - run: yarn build
       - run: yarn lint
-      #- run: yarn test
+
+      - name: Get the version number
+        id: version-number
+        run: echo "::set-output name=version::$(git describe --tags | tail -c +2)"
+        if: startsWith(github.ref, 'refs/tags/')
+
+      - name: Publish the package
+        run: yarn publish --new-version ${{ steps.version-number.outputs.version }} --non-interactive --no-git-tag-version
+        env:
+          NPM_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}
+        if: startsWith(github.ref, 'refs/tags/')

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "multinet",
-  "version": "0.18.0",
+  "version": "0.0.0-push-release",
   "description": "Multinet client library",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
This PR adds a couple of workflow steps that run only on push to certain tags, namely those following the pattern of `v<number>.<number>.<number>[<other stuff>?]`. When such a push occurs, these extra steps extract the version number and perform a publish action to NPM.

We can use this to publish pre-release versions on a branch we need to make use of for the client, and release versions after such branches are merged to master.

Because pushing of tags (or, I suppose, creating GitHub releases) becomes the main way to release to NPM, we no longer need to futz around with the `version` field of package.json, so this has been replaced with a dummy value that we won't need to update in the future.