### PR TITLE
Return item_id from the metadata call

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -87,6 +87,7 @@ export interface ColumnTypes {
 }
 
 export interface TableMetadata {
+  item_id: string;
   table: {
     columns: ColumnTypesEntry[];
   };


### PR DESCRIPTION
This adds `item_id` to the return of the metadata call. Currently the API does return the item_id and this typing will help in client apps that are connected using this library