### PR TITLE
Add "API key" login/logout method

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -42,6 +42,13 @@ export interface UserSpec {
   sub: string;
 }
 
+export interface UserSpec2 {
+  username: string;
+  first_name: string;
+  last_name: string;
+  admin: boolean;
+}
+
 export interface WorkspacePermissionsSpec {
   owner: UserSpec;
   maintainers: UserSpec[];
@@ -119,6 +126,14 @@ class MultinetAPI {
 
   public setAuthorizationToken(key: string) {
     this.axios.defaults.headers.common['Authorization'] = `Token ${key}`;
+  }
+
+  public _me(): AxiosPromise<UserSpec2> {
+    return this.client.get('/users/me');
+  }
+
+  public me(): Promise<UserSpec2> {
+    return extract(this._me());
   }
 
   public logout() {

--- a/src/index.ts
+++ b/src/index.ts
@@ -128,6 +128,10 @@ class MultinetAPI {
     this.axios.defaults.headers.common['Authorization'] = `Token ${key}`;
   }
 
+  public removeAuthorizationToken() {
+    delete this.client.defaults.headers.common['Authorization'];
+  }
+
   public _me(): AxiosPromise<UserSpec2> {
     return this.client.get('/users/me');
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -115,7 +115,10 @@ class MultinetAPI {
     this.axios = multinetAxiosInstance(axios.create({
       baseURL,
     }));
+  }
 
+  public setAuthorizationToken(key: string) {
+    this.axios.defaults.headers.common['Authorization'] = `Token ${key}`;
   }
 
   public logout() {

--- a/test/multinet.test.ts
+++ b/test/multinet.test.ts
@@ -1,4 +1,4 @@
-import { multinetApi } from '../src/index';
+import { multinetApi, MultinetAPI } from '../src/index';
 import { AxiosError } from 'axios';
 
 const badApi = multinetApi('http://example.com');
@@ -10,4 +10,27 @@ test('bad api', async () => {
   await expect(badApi.workspaces())
     .rejects
     .toHaveProperty('isAxiosError', true);
+});
+
+test('login with API key', async () => {
+  const api = multinetApi('http://localhost:8000/api');
+  expect(api).toBeInstanceOf(MultinetAPI);
+
+  try {
+    await api.me();
+    expect(false).toBe(true);
+  } catch (err) {
+    expect(err.response.status).toBe(401);
+    expect(err.response.data).toHaveProperty('detail', 'Authentication credentials were not provided.');
+  }
+
+  api.setAuthorizationToken('8fd781ff7ab9392b42f99bedd8acad2b6785d45e');
+
+  const me = await api.me();
+  expect(me).toStrictEqual({
+    username: 'root',
+    first_name: '',
+    last_name: '',
+    admin: true,
+  });
 });

--- a/test/multinet.test.ts
+++ b/test/multinet.test.ts
@@ -4,6 +4,8 @@ import { AxiosError } from 'axios';
 const badApi = multinetApi('http://example.com');
 
 test('bad api', async () => {
+  expect.assertions(2);
+
   expect(badApi).toBeInstanceOf(MultinetAPI);
 
   // The "bad api" object should fail when invoked.
@@ -13,12 +15,13 @@ test('bad api', async () => {
 });
 
 test('login with API key', async () => {
+  expect.assertions(6);
+
   const api = multinetApi('http://localhost:8000/api');
   expect(api).toBeInstanceOf(MultinetAPI);
 
   try {
     await api.me();
-    expect(false).toBe(true);
   } catch (err) {
     expect(err.response.status).toBe(401);
     expect(err.response.data).toHaveProperty('detail', 'Authentication credentials were not provided.');
@@ -38,7 +41,6 @@ test('login with API key', async () => {
 
   try {
     await api.me();
-    expect(false).toBe(true);
   } catch (err) {
     expect(err.response.status).toBe(401);
     expect(err.response.data).toHaveProperty('detail', 'Authentication credentials were not provided.');

--- a/test/multinet.test.ts
+++ b/test/multinet.test.ts
@@ -4,7 +4,7 @@ import { AxiosError } from 'axios';
 const badApi = multinetApi('http://example.com');
 
 test('bad api', async () => {
-  expect(badApi).toEqual(expect.anything());
+  expect(badApi).toBeInstanceOf(MultinetAPI);
 
   // The "bad api" object should fail when invoked.
   await expect(badApi.workspaces())

--- a/test/multinet.test.ts
+++ b/test/multinet.test.ts
@@ -33,4 +33,14 @@ test('login with API key', async () => {
     last_name: '',
     admin: true,
   });
+
+  api.removeAuthorizationToken();
+
+  try {
+    await api.me();
+    expect(false).toBe(true);
+  } catch (err) {
+    expect(err.response.status).toBe(401);
+    expect(err.response.data).toHaveProperty('detail', 'Authentication credentials were not provided.');
+  }
 });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -35,9 +35,7 @@
     ]
   },
   "include": [
-    "src/**/*.ts",
-    "test/**/*.ts",
-    "test/**/*.tsx"
+    "src/**/*.ts"
   ],
   "exclude": [
     "node_modules"


### PR DESCRIPTION
This PR enables the use of "API keys" with multinetjs.

Note that this is largely a proof of concept. The names of the methods and the way in which I'm setting/unsetting the appropriate header in the axios object (and any other detail here) are up for discussion.

This feature is mainly to enable unit tests for this library. Note that the tests will work locally if you change the API key string that appears in the test, and will not yet work in CI at all. Once this approach is agreed upon and refined, and the Girder4 Multinet stack is deployed to testing, we can put in a CI secret the actual API key to use for testing.

@zachmullen, I'm tagging you here mainly so you can see how I'm approaching the auth problems I discussed with you yesterday. Please feel free to leave a review, or just general feedback--either or both would be appreciated.

Depends on #30.