### PR TITLE
Fix return type for workspaces() in Girder4

### DIFF
--- a/src/axios.ts
+++ b/src/axios.ts
@@ -8,12 +8,13 @@ import {
   EdgesOptionsSpec,
   NodesSpec,
   OffsetLimitSpec,
+  Paginated,
   GraphSpec,
   RowsSpec,
   TablesOptionsSpec,
   UserSpec,
   WorkspacePermissionsSpec,
-  WorkspacesSpec,
+  Workspace,
 } from './index';
 
 function fileToText(file: File): Promise<string> {
@@ -36,7 +37,7 @@ function fileToText(file: File): Promise<string> {
 export interface MultinetAxiosInstance extends AxiosInstance {
   logout(): void;
   userInfo(): AxiosPromise<UserSpec | null>;
-  workspaces(): AxiosPromise<WorkspacesSpec>;
+  workspaces(): AxiosPromise<Paginated<Workspace>>;
   getWorkspacePermissions(workspace: string): AxiosPromise<WorkspacePermissionsSpec>;
   setWorkspacePermissions(workspace: string, permissions: WorkspacePermissionsSpec): AxiosPromise<WorkspacePermissionsSpec>;
   searchUsers(query: string): AxiosPromise<UserSpec[]>;
@@ -73,7 +74,7 @@ export function multinetAxiosInstance(config: AxiosRequestConfig): MultinetAxios
     return this.get('/user/info');
   }
 
-  Proto.workspaces = function(): AxiosPromise<WorkspacesSpec> {
+  Proto.workspaces = function(): AxiosPromise<Paginated<Workspace>> {
     return this.get('workspaces');
   };
 

--- a/src/axios.ts
+++ b/src/axios.ts
@@ -13,6 +13,7 @@ import {
   TablesOptionsSpec,
   UserSpec,
   WorkspacePermissionsSpec,
+  WorkspacesSpec,
 } from './index';
 
 function fileToText(file: File): Promise<string> {
@@ -35,7 +36,7 @@ function fileToText(file: File): Promise<string> {
 export interface MultinetAxiosInstance extends AxiosInstance {
   logout(): void;
   userInfo(): AxiosPromise<UserSpec | null>;
-  workspaces(): AxiosPromise<string[]>;
+  workspaces(): AxiosPromise<WorkspacesSpec>;
   getWorkspacePermissions(workspace: string): AxiosPromise<WorkspacePermissionsSpec>;
   setWorkspacePermissions(workspace: string, permissions: WorkspacePermissionsSpec): AxiosPromise<WorkspacePermissionsSpec>;
   searchUsers(query: string): AxiosPromise<UserSpec[]>;
@@ -72,7 +73,7 @@ export function multinetAxiosInstance(config: AxiosRequestConfig): MultinetAxios
     return this.get('/user/info');
   }
 
-  Proto.workspaces = function(): AxiosPromise<string[]> {
+  Proto.workspaces = function(): AxiosPromise<WorkspacesSpec> {
     return this.get('workspaces');
   };
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -50,6 +50,21 @@ export interface WorkspacePermissionsSpec {
   public: boolean;
 }
 
+export interface Workspace {
+  id: number;
+  name: string;
+  created: string;
+  modified: string;
+  arango_db_name: string;
+}
+
+export interface WorkspacesSpec {
+  count: number;
+  next: number;
+  previous: number;
+  results: Workspace[];
+}
+
 
 export type TableType = 'all' | 'node' | 'edge';
 
@@ -124,7 +139,7 @@ class MultinetAPI {
     return (await this.axios.userInfo()).data;
   }
 
-  public async workspaces(): Promise<string[]> {
+  public async workspaces(): Promise<WorkspacesSpec> {
     return (await this.axios.workspaces()).data;
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,13 @@ import { multinetAxiosInstance, MultinetAxiosInstance } from './axios';
 
 import axios, { AxiosRequestConfig } from 'axios';
 
+export interface Paginated<T> {
+  count: number,
+  next: string,
+  previous: string,
+  results: T[],
+}
+
 export interface TableRow {
   _key: string;
   _id: string;
@@ -58,12 +65,6 @@ export interface Workspace {
   arango_db_name: string;
 }
 
-export interface WorkspacesSpec {
-  count: number;
-  next: number;
-  previous: number;
-  results: Workspace[];
-}
 
 
 export type TableType = 'all' | 'node' | 'edge';
@@ -139,7 +140,7 @@ class MultinetAPI {
     return (await this.axios.userInfo()).data;
   }
 
-  public async workspaces(): Promise<WorkspacesSpec> {
+  public async workspaces(): Promise<Paginated<Workspace>> {
     return (await this.axios.workspaces()).data;
   }
 


### PR DESCRIPTION
This change is necessary to make the sidebar listing of workspaces work in Girder4.