### PR TITLE
Adapt multinetjs urls, parameters and return types to new Girder4 backend

### DIFF
--- a/src/axios.ts
+++ b/src/axios.ts
@@ -47,7 +47,6 @@ export interface MultinetAxiosInstance extends AxiosInstance {
   graphs(workspace: string): AxiosPromise<Paginated<Graph>>;
   graph(workspace: string, graph: string): AxiosPromise<GraphSpec>;
   nodes(workspace: string, graph: string, options: OffsetLimitSpec): AxiosPromise<Paginated<TableRow>>;
-  attributes(workspace: string, graph: string, nodeId: string): AxiosPromise<{}>;
   edges(workspace: string, graph: string, nodeId: string, options: EdgesOptionsSpec): AxiosPromise<Paginated<EdgesSpec>>;
   createWorkspace(workspace: string): AxiosPromise<string>;
   deleteWorkspace(workspace: string): AxiosPromise<string>;
@@ -123,11 +122,7 @@ export function multinetAxiosInstance(config: AxiosRequestConfig): MultinetAxios
     });
   };
 
-  Proto.attributes = function(workspace: string, graph: string, nodeId: string): AxiosPromise<{}> {
-    return this.get(`workspaces/${workspace}/networks/${graph}/nodes/${nodeId}/attributes`);
-  };
-
-  Proto.edges = function(workspace: string, graph: string, nodeId: string, options: EdgesOptionsSpec = {}): AxiosPromise<Paginated<EdgesSpec>> {
+  Proto.edges = function(workspace: string, graph: string, options: EdgesOptionsSpec = {}): AxiosPromise<Paginated<EdgesSpec>> {
     return this.get(`workspaces/${workspace}/networks/${graph}/edges`, {
       params: options,
     });

--- a/src/axios.ts
+++ b/src/axios.ts
@@ -8,12 +8,13 @@ import {
   EdgesOptionsSpec,
   NodesSpec,
   OffsetLimitSpec,
+  Paginated,
   GraphSpec,
   RowsSpec,
   TablesOptionsSpec,
   UserSpec,
   WorkspacePermissionsSpec,
-  WorkspacesSpec,
+  Workspace,
 } from './index';
 
 function fileToText(file: File): Promise<string> {
@@ -36,7 +37,7 @@ function fileToText(file: File): Promise<string> {
 export interface MultinetAxiosInstance extends AxiosInstance {
   logout(): void;
   userInfo(): AxiosPromise<UserSpec | null>;
-  workspaces(): AxiosPromise<WorkspacesSpec>;
+  workspaces(): AxiosPromise<Paginated<Workspace>>;
   getWorkspacePermissions(workspace: string): AxiosPromise<WorkspacePermissionsSpec>;
   setWorkspacePermissions(workspace: string, permissions: WorkspacePermissionsSpec): AxiosPromise<WorkspacePermissionsSpec>;
   searchUsers(query: string): AxiosPromise<UserSpec[]>;
@@ -73,7 +74,7 @@ export function multinetAxiosInstance(config: AxiosRequestConfig): MultinetAxios
     return this.get('/user/info');
   };
 
-  Proto.workspaces = function(): AxiosPromise<WorkspacesSpec> {
+  Proto.workspaces = function(): AxiosPromise<Paginated<Workspace>> {
     return this.get('workspaces');
   };
 

--- a/src/axios.ts
+++ b/src/axios.ts
@@ -41,7 +41,7 @@ export interface MultinetAxiosInstance extends AxiosInstance {
   workspaces(): AxiosPromise<Paginated<Workspace>>;
   getWorkspacePermissions(workspace: string): AxiosPromise<WorkspacePermissionsSpec>;
   setWorkspacePermissions(workspace: string, permissions: WorkspacePermissionsSpec): AxiosPromise<WorkspacePermissionsSpec>;
-  searchUsers(query: string): AxiosPromise<UserSpec[]>;
+  searchUsers(username: string): AxiosPromise<UserSpec[]>;
   tables(workspace: string, options: TablesOptionsSpec): AxiosPromise<Paginated<Table>>;
   table(workspace: string, table: string, options: OffsetLimitSpec): AxiosPromise<Paginated<TableRow>>;
   graphs(workspace: string): AxiosPromise<Paginated<Graph>>;
@@ -89,10 +89,10 @@ export function multinetAxiosInstance(config: AxiosRequestConfig): MultinetAxios
     });
   };
 
-  Proto.searchUsers = function(query: string): AxiosPromise<UserSpec[]> {
-    return this.get('/user/search', {
+  Proto.searchUsers = function(username: string): AxiosPromise<UserSpec[]> {
+    return this.get('/users/search', {
       params: {
-        query,
+        username,
       },
     });
   };
@@ -104,37 +104,39 @@ export function multinetAxiosInstance(config: AxiosRequestConfig): MultinetAxios
   };
 
   Proto.table = function(workspace: string, table: string, options: OffsetLimitSpec = {}): AxiosPromise<Paginated<TableRow>> {
-    return this.get(`workspaces/${workspace}/tables/${table}`, {
+    return this.get(`workspaces/${workspace}/tables/${table}/rows`, {
       params: options,
     });
   };
 
   Proto.graphs = function(workspace: string): AxiosPromise<Paginated<Graph>> {
-    return this.get(`workspaces/${workspace}/graphs`);
+    return this.get(`workspaces/${workspace}/networks`);
   };
 
   Proto.graph = function(workspace: string, graph: string): AxiosPromise<GraphSpec> {
-    return this.get(`workspaces/${workspace}/graphs/${graph}`);
+    return this.get(`workspaces/${workspace}/networks/${graph}`);
   };
 
   Proto.nodes = function(workspace: string, graph: string, options: OffsetLimitSpec = {}): AxiosPromise<Paginated<TableRow>> {
-    return this.get(`workspaces/${workspace}/graphs/${graph}/nodes`, {
+    return this.get(`workspaces/${workspace}/networks/${graph}/nodes`, {
       params: options,
     });
   };
 
   Proto.attributes = function(workspace: string, graph: string, nodeId: string): AxiosPromise<{}> {
-    return this.get(`workspaces/${workspace}/graphs/${graph}/nodes/${nodeId}/attributes`);
+    return this.get(`workspaces/${workspace}/networks/${graph}/nodes/${nodeId}/attributes`);
   };
 
   Proto.edges = function(workspace: string, graph: string, nodeId: string, options: EdgesOptionsSpec = {}): AxiosPromise<Paginated<EdgesSpec>> {
-    return this.get(`workspaces/${workspace}/graphs/${graph}/nodes/${nodeId}/edges`, {
+    return this.get(`workspaces/${workspace}/networks/${graph}/nodes/${nodeId}/edges`, {
       params: options,
     });
   };
 
   Proto.createWorkspace = function(workspace: string): AxiosPromise<string> {
-    return this.post(`/workspaces/${workspace}`);
+    return this.post(`/workspaces/`, {
+      name: workspace,
+    });
   };
 
   Proto.deleteWorkspace = function(workspace: string): AxiosPromise<string> {
@@ -197,13 +199,14 @@ export function multinetAxiosInstance(config: AxiosRequestConfig): MultinetAxios
   };
 
   Proto.createGraph = function(workspace: string, graph: string, options: CreateGraphOptionsSpec): AxiosPromise<CreateGraphOptionsSpec> {
-    return this.post(`/workspaces/${workspace}/graphs/${graph}`, {
+    return this.post(`/workspaces/${workspace}/networks/`, {
+      name: graph,
       edge_table: options.edgeTable,
     });
   };
 
   Proto.deleteGraph = function(workspace: string, graph: string): AxiosPromise<string> {
-    return this.delete(`/workspaces/${workspace}/graphs/${graph}`);
+    return this.delete(`/workspaces/${workspace}/networks/${graph}`);
   };
 
   Proto.aql = function(workspace: string, query: string): AxiosPromise<any[]> {

--- a/src/axios.ts
+++ b/src/axios.ts
@@ -47,7 +47,7 @@ export interface MultinetAxiosInstance extends AxiosInstance {
   graphs(workspace: string): AxiosPromise<Paginated<Graph>>;
   graph(workspace: string, graph: string): AxiosPromise<GraphSpec>;
   nodes(workspace: string, graph: string, options: OffsetLimitSpec): AxiosPromise<Paginated<TableRow>>;
-  edges(workspace: string, graph: string, nodeId: string, options: EdgesOptionsSpec): AxiosPromise<Paginated<EdgesSpec>>;
+  edges(workspace: string, graph: string, options: EdgesOptionsSpec): AxiosPromise<Paginated<EdgesSpec>>;
   createWorkspace(workspace: string): AxiosPromise<string>;
   deleteWorkspace(workspace: string): AxiosPromise<string>;
   renameWorkspace(workspace: string, name: string): AxiosPromise<any>;

--- a/src/axios.ts
+++ b/src/axios.ts
@@ -128,7 +128,7 @@ export function multinetAxiosInstance(config: AxiosRequestConfig): MultinetAxios
   };
 
   Proto.edges = function(workspace: string, graph: string, nodeId: string, options: EdgesOptionsSpec = {}): AxiosPromise<Paginated<EdgesSpec>> {
-    return this.get(`workspaces/${workspace}/networks/${graph}/nodes/${nodeId}/edges`, {
+    return this.get(`workspaces/${workspace}/networks/${graph}/edges`, {
       params: options,
     });
   };

--- a/src/axios.ts
+++ b/src/axios.ts
@@ -13,6 +13,7 @@ import {
   TablesOptionsSpec,
   UserSpec,
   WorkspacePermissionsSpec,
+  WorkspacesSpec,
 } from './index';
 
 function fileToText(file: File): Promise<string> {
@@ -35,7 +36,7 @@ function fileToText(file: File): Promise<string> {
 export interface MultinetAxiosInstance extends AxiosInstance {
   logout(): void;
   userInfo(): AxiosPromise<UserSpec | null>;
-  workspaces(): AxiosPromise<string[]>;
+  workspaces(): AxiosPromise<WorkspacesSpec>;
   getWorkspacePermissions(workspace: string): AxiosPromise<WorkspacePermissionsSpec>;
   setWorkspacePermissions(workspace: string, permissions: WorkspacePermissionsSpec): AxiosPromise<WorkspacePermissionsSpec>;
   searchUsers(query: string): AxiosPromise<UserSpec[]>;
@@ -72,7 +73,7 @@ export function multinetAxiosInstance(config: AxiosRequestConfig): MultinetAxios
     return this.get('/user/info');
   };
 
-  Proto.workspaces = function(): AxiosPromise<string[]> {
+  Proto.workspaces = function(): AxiosPromise<WorkspacesSpec> {
     return this.get('workspaces');
   };
 

--- a/src/axios.ts
+++ b/src/axios.ts
@@ -6,12 +6,13 @@ import {
   FileUploadOptionsSpec,
   EdgesSpec,
   EdgesOptionsSpec,
-  NodesSpec,
+  Graph,
   OffsetLimitSpec,
   Paginated,
   GraphSpec,
-  RowsSpec,
+  TableRow,
   TablesOptionsSpec,
+  Table,
   UserSpec,
   WorkspacePermissionsSpec,
   Workspace,
@@ -41,13 +42,13 @@ export interface MultinetAxiosInstance extends AxiosInstance {
   getWorkspacePermissions(workspace: string): AxiosPromise<WorkspacePermissionsSpec>;
   setWorkspacePermissions(workspace: string, permissions: WorkspacePermissionsSpec): AxiosPromise<WorkspacePermissionsSpec>;
   searchUsers(query: string): AxiosPromise<UserSpec[]>;
-  tables(workspace: string, options: TablesOptionsSpec): AxiosPromise<string[]>;
-  table(workspace: string, table: string, options: OffsetLimitSpec): AxiosPromise<RowsSpec>;
-  graphs(workspace: string): AxiosPromise<string[]>;
+  tables(workspace: string, options: TablesOptionsSpec): AxiosPromise<Paginated<Table>>;
+  table(workspace: string, table: string, options: OffsetLimitSpec): AxiosPromise<Paginated<TableRow>>;
+  graphs(workspace: string): AxiosPromise<Paginated<Graph>>;
   graph(workspace: string, graph: string): AxiosPromise<GraphSpec>;
-  nodes(workspace: string, graph: string, options: OffsetLimitSpec): AxiosPromise<NodesSpec>;
+  nodes(workspace: string, graph: string, options: OffsetLimitSpec): AxiosPromise<Paginated<TableRow>>;
   attributes(workspace: string, graph: string, nodeId: string): AxiosPromise<{}>;
-  edges(workspace: string, graph: string, nodeId: string, options: EdgesOptionsSpec): AxiosPromise<EdgesSpec>;
+  edges(workspace: string, graph: string, nodeId: string, options: EdgesOptionsSpec): AxiosPromise<Paginated<EdgesSpec>>;
   createWorkspace(workspace: string): AxiosPromise<string>;
   deleteWorkspace(workspace: string): AxiosPromise<string>;
   renameWorkspace(workspace: string, name: string): AxiosPromise<any>;
@@ -55,7 +56,7 @@ export interface MultinetAxiosInstance extends AxiosInstance {
   downloadTable(workspace: string, table: string): AxiosPromise<any>;
   deleteTable(workspace: string, table: string): AxiosPromise<string>;
   tableMetadata(workspace: string, table: string): AxiosPromise<TableMetadata>;
-  createGraph(workspace: string, graph: string, options: CreateGraphOptionsSpec): AxiosPromise<string>;
+  createGraph(workspace: string, graph: string, options: CreateGraphOptionsSpec): AxiosPromise<CreateGraphOptionsSpec>;
   deleteGraph(workspace: string, graph: string): AxiosPromise<string>;
   aql(workspace: string, query: string): AxiosPromise<any[]>;
   createAQLTable(workspace: string, table: string, query: string): AxiosPromise<any[]>;
@@ -96,19 +97,19 @@ export function multinetAxiosInstance(config: AxiosRequestConfig): MultinetAxios
     });
   };
 
-  Proto.tables = function(workspace: string, options: TablesOptionsSpec = {}): AxiosPromise<string[]> {
+  Proto.tables = function(workspace: string, options: TablesOptionsSpec = {}): AxiosPromise<Paginated<Table>> {
     return this.get(`workspaces/${workspace}/tables`, {
       params: options,
     });
   };
 
-  Proto.table = function(workspace: string, table: string, options: OffsetLimitSpec = {}): AxiosPromise<RowsSpec> {
+  Proto.table = function(workspace: string, table: string, options: OffsetLimitSpec = {}): AxiosPromise<Paginated<TableRow>> {
     return this.get(`workspaces/${workspace}/tables/${table}`, {
       params: options,
     });
   };
 
-  Proto.graphs = function(workspace: string): AxiosPromise<string[]> {
+  Proto.graphs = function(workspace: string): AxiosPromise<Paginated<Graph>> {
     return this.get(`workspaces/${workspace}/graphs`);
   };
 
@@ -116,7 +117,7 @@ export function multinetAxiosInstance(config: AxiosRequestConfig): MultinetAxios
     return this.get(`workspaces/${workspace}/graphs/${graph}`);
   };
 
-  Proto.nodes = function(workspace: string, graph: string, options: OffsetLimitSpec = {}): AxiosPromise<NodesSpec> {
+  Proto.nodes = function(workspace: string, graph: string, options: OffsetLimitSpec = {}): AxiosPromise<Paginated<TableRow>> {
     return this.get(`workspaces/${workspace}/graphs/${graph}/nodes`, {
       params: options,
     });
@@ -126,7 +127,7 @@ export function multinetAxiosInstance(config: AxiosRequestConfig): MultinetAxios
     return this.get(`workspaces/${workspace}/graphs/${graph}/nodes/${nodeId}/attributes`);
   };
 
-  Proto.edges = function(workspace: string, graph: string, nodeId: string, options: EdgesOptionsSpec = {}): AxiosPromise<EdgesSpec> {
+  Proto.edges = function(workspace: string, graph: string, nodeId: string, options: EdgesOptionsSpec = {}): AxiosPromise<Paginated<EdgesSpec>> {
     return this.get(`workspaces/${workspace}/graphs/${graph}/nodes/${nodeId}/edges`, {
       params: options,
     });
@@ -195,7 +196,7 @@ export function multinetAxiosInstance(config: AxiosRequestConfig): MultinetAxios
     return this.get(`/workspaces/${workspace}/tables/${table}/metadata`);
   };
 
-  Proto.createGraph = function(workspace: string, graph: string, options: CreateGraphOptionsSpec): AxiosPromise<string> {
+  Proto.createGraph = function(workspace: string, graph: string, options: CreateGraphOptionsSpec): AxiosPromise<CreateGraphOptionsSpec> {
     return this.post(`/workspaces/${workspace}/graphs/${graph}`, {
       edge_table: options.edgeTable,
     });

--- a/src/axios.ts
+++ b/src/axios.ts
@@ -72,7 +72,7 @@ export function multinetAxiosInstance(config: AxiosRequestConfig): MultinetAxios
   };
 
   Proto.userInfo = function(): AxiosPromise<UserSpec | null> {
-    return this.get('/user/info');
+    return this.get('/users/me');
   };
 
   Proto.workspaces = function(): AxiosPromise<Paginated<Workspace>> {

--- a/src/index.ts
+++ b/src/index.ts
@@ -50,6 +50,21 @@ export interface WorkspacePermissionsSpec {
   public: boolean;
 }
 
+export interface Workspace {
+  id: number;
+  name: string;
+  created: string;
+  modified: string;
+  arango_db_name: string;
+}
+
+export interface WorkspacesSpec {
+  count: number;
+  next: number;
+  previous: number;
+  results: Workspace[];
+}
+
 
 export type TableType = 'all' | 'node' | 'edge';
 
@@ -124,7 +139,7 @@ class MultinetAPI {
     return (await this.axios.userInfo()).data;
   }
 
-  public async workspaces(): Promise<string[]> {
+  public async workspaces(): Promise<WorkspacesSpec> {
     return (await this.axios.workspaces()).data;
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,40 +9,56 @@ export interface Paginated<T> {
   results: T[],
 }
 
+export interface Table {
+  name: string;
+  edge: boolean;
+  id: number;
+  created: string;
+  modified: string;
+  workspace: Workspace[];
+}
+
 export interface TableRow {
   _key: string;
   _id: string;
 }
 
+export interface Graph {
+  id: number;
+  name: string;
+  created: string;
+  modified: string;
+}
+
 export interface GraphSpec {
-  edgeTable: string;
-  nodeTables: string[];
+  id: number;
+  name: string;
+  node_count: number;
+  edge_count: number;
+  created: string;
+  modified: string;
+  workspace: Workspace;
 }
 
-export interface NodesSpec {
-  count: number;
-  nodes: TableRow[];
-}
-
-export interface RowsSpec {
-  count: number;
-  rows: TableRow[];
-}
 
 export interface Edge {
-  edge: string;
   from: string;
   to: string;
 }
 
 export interface EdgesSpec {
-  count: number;
-  edges: Edge[];
+  _key: string;
+  _id: string;
+  _from: string;
+  _to: string;
+  _rev: string;
 }
 
 export interface UserSpec {
-  family_name: string;
-  given_name: string;
+  username: string;
+  first_name: string;
+  last_name: string;
+  admin: boolean;
   name: string;
   picture: string;
   email: string;
@@ -166,15 +182,15 @@ class MultinetAPI {
     return (await this.axios.searchUsers(query)).data;
   }
 
-  public async tables(workspace: string, options: TablesOptionsSpec = {}): Promise<string[]> {
+  public async tables(workspace: string, options: TablesOptionsSpec = {}): Promise<Paginated<Table>> {
     return (await this.axios.tables(workspace, options)).data;
   }
 
-  public async table(workspace: string, table: string, options: OffsetLimitSpec = {}): Promise<RowsSpec> {
+  public async table(workspace: string, table: string, options: OffsetLimitSpec = {}): Promise<Paginated<TableRow>> {
     return (await this.axios.table(workspace, table, options)).data;
   }
 
-  public async graphs(workspace: string): Promise<string[]> {
+  public async graphs(workspace: string): Promise<Paginated<Graph>> {
     return (await this.axios.graphs(workspace)).data;
   }
 
@@ -182,7 +198,7 @@ class MultinetAPI {
     return (await this.axios.graph(workspace, graph)).data;
   }
 
-  public async nodes(workspace: string, graph: string, options: OffsetLimitSpec = {}): Promise<NodesSpec> {
+  public async nodes(workspace: string, graph: string, options: OffsetLimitSpec = {}): Promise<Paginated<TableRow>> {
     return (await this.axios.nodes(workspace, graph, options)).data;
   }
 
@@ -190,7 +206,7 @@ class MultinetAPI {
     return (await this.axios.attributes(workspace, graph, nodeId)).data;
   }
 
-  public async edges(workspace: string, graph: string, nodeId: string, options: EdgesOptionsSpec = {}): Promise<EdgesSpec> {
+  public async edges(workspace: string, graph: string, nodeId: string, options: EdgesOptionsSpec = {}): Promise<Paginated<EdgesSpec>> {
     return (await this.axios.edges(workspace, graph, nodeId, options)).data;
   }
 
@@ -234,7 +250,7 @@ class MultinetAPI {
     return types;
   }
 
-  public async createGraph(workspace: string, graph: string, options: CreateGraphOptionsSpec): Promise<string> {
+  public async createGraph(workspace: string, graph: string, options: CreateGraphOptionsSpec): Promise<CreateGraphOptionsSpec> {
     return (await this.axios.createGraph(workspace, graph, options)).data;
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,13 @@ import { multinetAxiosInstance, MultinetAxiosInstance } from './axios';
 
 import axios, { AxiosRequestConfig } from 'axios';
 
+export interface Paginated<T> {
+  count: number,
+  next: string,
+  previous: string,
+  results: T[],
+}
+
 export interface TableRow {
   _key: string;
   _id: string;
@@ -58,12 +65,6 @@ export interface Workspace {
   arango_db_name: string;
 }
 
-export interface WorkspacesSpec {
-  count: number;
-  next: number;
-  previous: number;
-  results: Workspace[];
-}
 
 
 export type TableType = 'all' | 'node' | 'edge';
@@ -139,7 +140,7 @@ class MultinetAPI {
     return (await this.axios.userInfo()).data;
   }
 
-  public async workspaces(): Promise<WorkspacesSpec> {
+  public async workspaces(): Promise<Paginated<Workspace>> {
     return (await this.axios.workspaces()).data;
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -178,8 +178,8 @@ class MultinetAPI {
     return (await this.axios.setWorkspacePermissions(workspace, permissions)).data;
   }
 
-  public async searchUsers(query: string): Promise<UserSpec[]> {
-    return (await this.axios.searchUsers(query)).data;
+  public async searchUsers(username: string): Promise<UserSpec[]> {
+    return (await this.axios.searchUsers(username)).data;
   }
 
   public async tables(workspace: string, options: TablesOptionsSpec = {}): Promise<Paginated<Table>> {

--- a/src/index.ts
+++ b/src/index.ts
@@ -197,8 +197,8 @@ class MultinetAPI {
     return (await this.axios.nodes(workspace, graph, options)).data;
   }
 
-  public async edges(workspace: string, graph: string, nodeId: string, options: EdgesOptionsSpec = {}): Promise<Paginated<EdgesSpec>> {
-    return (await this.axios.edges(workspace, graph, nodeId, options)).data;
+  public async edges(workspace: string, graph: string, options: EdgesOptionsSpec = {}): Promise<Paginated<EdgesSpec>> {
+    return (await this.axios.edges(workspace, graph, options)).data;
   }
 
   public async createWorkspace(workspace: string): Promise<string> {

--- a/src/index.ts
+++ b/src/index.ts
@@ -40,12 +40,6 @@ export interface GraphSpec {
   workspace: Workspace;
 }
 
-
-export interface Edge {
-  from: string;
-  to: string;
-}
-
 export interface EdgesSpec {
   _key: string;
   _id: string;
@@ -200,10 +194,6 @@ class MultinetAPI {
 
   public async nodes(workspace: string, graph: string, options: OffsetLimitSpec = {}): Promise<Paginated<TableRow>> {
     return (await this.axios.nodes(workspace, graph, options)).data;
-  }
-
-  public async attributes(workspace: string, graph: string, nodeId: string): Promise<{}> {
-    return (await this.axios.attributes(workspace, graph, nodeId)).data;
   }
 
   public async edges(workspace: string, graph: string, nodeId: string, options: EdgesOptionsSpec = {}): Promise<Paginated<EdgesSpec>> {

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,8 +4,8 @@ import axios, { AxiosRequestConfig } from 'axios';
 
 export interface Paginated<T> {
   count: number,
-  next: string,
-  previous: string,
+  next: string | null,
+  previous: string | null,
   results: T[],
 }
 
@@ -15,12 +15,13 @@ export interface Table {
   id: number;
   created: string;
   modified: string;
-  workspace: Workspace[];
+  workspace: Workspace;
 }
 
 export interface TableRow {
   _key: string;
   _id: string;
+  _rev: string;
 }
 
 export interface Graph {


### PR DESCRIPTION
This PR includes changes to the interfaces, parameters and urls used in the multinetjs library to match the information and data structures returned by the new API.

Works in conjunction with changes found in the [django-updates](https://github.com/multinet-app/multinet-client/tree/django-updates) branch of multinet-client

Resolves #29