### PR TITLE
Reconfigure to enable file uploading using S3 File Field

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "axios": "^0.21.1",
+    "django-s3-file-field": "^0.1.2",
     "ts-jest": "^26.5.4"
   },
   "devDependencies": {

--- a/src/axios.ts
+++ b/src/axios.ts
@@ -156,10 +156,7 @@ export function multinetAxiosInstance(config: AxiosRequestConfig): MultinetAxios
       apiConfig: this.defaults,
     });
     
-    const fieldValue = await s3ffClient.uploadFile(
-      data as File,
-      'api.Upload.blob'
-    );
+    const fieldValue = await s3ffClient.uploadFile(data, 'api.Upload.blob');
 
     return this.post(`/workspaces/${workspace}/uploads/csv/`, {
       field_value: fieldValue.value,
@@ -188,10 +185,7 @@ export function multinetAxiosInstance(config: AxiosRequestConfig): MultinetAxios
       apiConfig: this.defaults,
     });
 
-    const fieldValue = await s3ffClient.uploadFile(
-      data as File,
-      'api.Upload.blob'
-    );
+    const fieldValue = await s3ffClient.uploadFile(data, 'api.Upload.blob');
 
     return this.post(`/workspaces/${workspace}/uploads/${type}/`, {
       field_value: fieldValue.value,

--- a/src/axios.ts
+++ b/src/axios.ts
@@ -4,7 +4,8 @@ import S3FileFieldClient, { S3FileFieldProgress, S3FileFieldProgressState } from
 import {
   CreateGraphOptionsSpec,
   TableMetadata,
-  FileUploadOptionsSpec,
+  TableUploadOptionsSpec,
+  NetworkUploadOptionsSpec,
   EdgesSpec,
   EdgesOptionsSpec,
   Graph,
@@ -52,11 +53,11 @@ export interface MultinetAxiosInstance extends AxiosInstance {
   createWorkspace(workspace: string): AxiosPromise<string>;
   deleteWorkspace(workspace: string): AxiosPromise<string>;
   renameWorkspace(workspace: string, name: string): AxiosPromise<any>;
-  uploadTable(workspace: string, table: string, options: FileUploadOptionsSpec, config?: AxiosRequestConfig): AxiosPromise<Array<{}>>;
+  uploadTable(workspace: string, table: string, options: TableUploadOptionsSpec, config?: AxiosRequestConfig): AxiosPromise<Array<{}>>;
   downloadTable(workspace: string, table: string): AxiosPromise<any>;
   deleteTable(workspace: string, table: string): AxiosPromise<string>;
   tableMetadata(workspace: string, table: string): AxiosPromise<TableMetadata>;
-  uploadNetwork(workspace: string, network: string, options: FileUploadOptionsSpec, config?: AxiosRequestConfig): AxiosPromise<Array<{}>>;
+  uploadNetwork(workspace: string, network: string, options: NetworkUploadOptionsSpec, config?: AxiosRequestConfig): AxiosPromise<Array<{}>>;
   createGraph(workspace: string, graph: string, options: CreateGraphOptionsSpec): AxiosPromise<CreateGraphOptionsSpec>;
   deleteGraph(workspace: string, graph: string): AxiosPromise<string>;
   aql(workspace: string, query: string): AxiosPromise<any[]>;
@@ -148,10 +149,10 @@ export function multinetAxiosInstance(config: AxiosRequestConfig): MultinetAxios
     });
   };
 
-  Proto.uploadTable = async function(workspace: string, table: string, options: FileUploadOptionsSpec, config?: AxiosRequestConfig): Promise<AxiosResponse<Array<{}>>> {
+  Proto.uploadTable = async function(workspace: string, table: string, options: TableUploadOptionsSpec, config?: AxiosRequestConfig): Promise<AxiosResponse<Array<{}>>> {
     const headers = config ? config.headers : undefined;
     const params = config ? config.params : undefined;
-    const { data, edgeTable, key, overwrite, columnTypes } = options;
+    const { data, edgeTable, columnTypes } = options;
     const s3ffClient = new S3FileFieldClient({
       baseUrl: `${this.defaults.baseURL}/s3-upload/`,
       apiConfig: this.defaults,
@@ -177,8 +178,6 @@ export function multinetAxiosInstance(config: AxiosRequestConfig): MultinetAxios
       headers: { ...headers, 'Content-Type': 'text/plain' },
       params: {
         ...params,
-        key: key || undefined,
-        overwrite: overwrite || undefined,
         metadata: metadata || undefined,
       },
       field_value: fieldValue.value,
@@ -200,7 +199,7 @@ export function multinetAxiosInstance(config: AxiosRequestConfig): MultinetAxios
     return this.get(`/workspaces/${workspace}/tables/${table}/metadata`);
   };
 
-  Proto.uploadNetwork = async function(workspace: string, network: string, options: FileUploadOptionsSpec, config?: AxiosRequestConfig): Promise<AxiosResponse<Array<{}>>> {
+  Proto.uploadNetwork = async function(workspace: string, network: string, options: NetworkUploadOptionsSpec, config?: AxiosRequestConfig): Promise<AxiosResponse<Array<{}>>> {
     const headers = config ? config.headers : undefined;
     const params = config ? config.params : undefined;
     const { type, data } = options;

--- a/src/axios.ts
+++ b/src/axios.ts
@@ -149,9 +149,7 @@ export function multinetAxiosInstance(config: AxiosRequestConfig): MultinetAxios
     });
   };
 
-  Proto.uploadTable = async function(workspace: string, table: string, options: TableUploadOptionsSpec, config?: AxiosRequestConfig): Promise<AxiosResponse<Array<{}>>> {
-    const headers = config ? config.headers : undefined;
-    const params = config ? config.params : undefined;
+  Proto.uploadTable = async function(workspace: string, table: string, options: TableUploadOptionsSpec): Promise<AxiosResponse<Array<{}>>> {
     const { data, edgeTable, columnTypes } = options;
     const s3ffClient = new S3FileFieldClient({
       baseUrl: `${this.defaults.baseURL}/s3-upload/`,
@@ -174,12 +172,6 @@ export function multinetAxiosInstance(config: AxiosRequestConfig): MultinetAxios
     }
 
     return this.post(`/workspaces/${workspace}/uploads/csv/`, {
-      ...config,
-      headers: { ...headers, 'Content-Type': 'text/plain' },
-      params: {
-        ...params,
-        metadata: metadata || undefined,
-      },
       field_value: fieldValue.value,
       edge: edgeTable,
       table_name: table,
@@ -199,13 +191,10 @@ export function multinetAxiosInstance(config: AxiosRequestConfig): MultinetAxios
     return this.get(`/workspaces/${workspace}/tables/${table}/metadata`);
   };
 
-  Proto.uploadNetwork = async function(workspace: string, network: string, options: NetworkUploadOptionsSpec, config?: AxiosRequestConfig): Promise<AxiosResponse<Array<{}>>> {
-    const headers = config ? config.headers : undefined;
-    const params = config ? config.params : undefined;
+  Proto.uploadNetwork = async function(workspace: string, network: string, options: NetworkUploadOptionsSpec): Promise<AxiosResponse<Array<{}>>> {
     const { type, data } = options;
     const s3ffClient = new S3FileFieldClient({
       baseUrl: `${this.defaults.baseURL}/s3-upload/`,
-      // onProgress: onUploadProgress, // This argument is optional
       apiConfig: this.defaults,
     });
 
@@ -215,9 +204,6 @@ export function multinetAxiosInstance(config: AxiosRequestConfig): MultinetAxios
     );
 
     return this.post(`/workspaces/${workspace}/uploads/${type}/`, {
-      ...config,
-      headers: { ...headers, 'Content-Type': 'text/plain' },
-      ...params,
       field_value: fieldValue.value,
       network_name: network
     });

--- a/src/axios.ts
+++ b/src/axios.ts
@@ -161,16 +161,6 @@ export function multinetAxiosInstance(config: AxiosRequestConfig): MultinetAxios
       'api.Upload.blob'
     );
 
-    let metadata;
-    if (columnTypes) {
-      const columns = Object.keys(columnTypes).map((column) => ({
-        key: column,
-        type: columnTypes[column],
-      }));
-
-      metadata = { columns };
-    }
-
     return this.post(`/workspaces/${workspace}/uploads/csv/`, {
       field_value: fieldValue.value,
       edge: edgeTable,

--- a/src/axios.ts
+++ b/src/axios.ts
@@ -151,9 +151,9 @@ export function multinetAxiosInstance(config: AxiosRequestConfig): MultinetAxios
   Proto.uploadTable = async function(workspace: string, table: string, options: FileUploadOptionsSpec, config?: AxiosRequestConfig): Promise<AxiosResponse<Array<{}>>> {
     const headers = config ? config.headers : undefined;
     const params = config ? config.params : undefined;
-    const { data, edgeTable, url, key, overwrite, columnTypes } = options;
+    const { data, edgeTable, key, overwrite, columnTypes } = options;
     const s3ffClient = new S3FileFieldClient({
-      baseUrl: `${url}/api/s3-upload/`,
+      baseUrl: `${this.defaults.baseURL}/s3-upload/`,
       apiConfig: this.defaults,
     });
     
@@ -203,9 +203,9 @@ export function multinetAxiosInstance(config: AxiosRequestConfig): MultinetAxios
   Proto.uploadNetwork = async function(workspace: string, network: string, options: FileUploadOptionsSpec, config?: AxiosRequestConfig): Promise<AxiosResponse<Array<{}>>> {
     const headers = config ? config.headers : undefined;
     const params = config ? config.params : undefined;
-    const { type, data, url } = options;
+    const { type, data } = options;
     const s3ffClient = new S3FileFieldClient({
-      baseUrl: `${url}/api/s3-upload/`,
+      baseUrl: `${this.defaults.baseURL}/s3-upload/`,
       // onProgress: onUploadProgress, // This argument is optional
       apiConfig: this.defaults,
     });

--- a/src/index.ts
+++ b/src/index.ts
@@ -121,15 +121,18 @@ export interface TableMetadata {
   };
 }
 
-export interface FileUploadOptionsSpec {
+export interface TableUploadOptionsSpec {
   type: UploadType;
   data: File;
-  edgeTable?: boolean;
-  key?: string;
-  overwrite?: boolean;
+  edgeTable: boolean;
   columnTypes?: {
     [key: string]: ColumnType;
   };
+}
+
+export interface NetworkUploadOptionsSpec {
+  data: File;
+  type: GraphUploadType;
 }
 
 export interface CreateGraphOptionsSpec {
@@ -215,7 +218,7 @@ class MultinetAPI {
   }
 
   public async uploadTable(
-    workspace: string, table: string, options: FileUploadOptionsSpec, config?: AxiosRequestConfig
+    workspace: string, table: string, options: TableUploadOptionsSpec, config?: AxiosRequestConfig
   ): Promise<Array<{}>> {
     return (await this.axios.uploadTable(workspace, table, options, config)).data;
   }
@@ -242,7 +245,7 @@ class MultinetAPI {
     return types;
   }
 
-  public async uploadNetwork(workspace: string, network: string, options: FileUploadOptionsSpec, config?: AxiosRequestConfig): Promise<Array<{}>> {
+  public async uploadNetwork(workspace: string, network: string, options: NetworkUploadOptionsSpec, config?: AxiosRequestConfig): Promise<Array<{}>> {
     return (await this.axios.uploadNetwork(workspace, network, options, config)).data;
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -128,7 +128,6 @@ export interface TableMetadata {
 }
 
 export interface TableUploadOptionsSpec {
-  type: UploadType;
   data: File;
   edgeTable: boolean;
   columnTypes?: {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,5 @@
 import { multinetAxiosInstance, MultinetAxiosInstance } from './axios';
 
-import axios, { AxiosRequestConfig } from 'axios';
-
 export interface Paginated<T> {
   count: number,
   next: string | null,
@@ -217,10 +215,8 @@ class MultinetAPI {
     return (await this.axios.renameWorkspace(workspace, name)).data;
   }
 
-  public async uploadTable(
-    workspace: string, table: string, options: TableUploadOptionsSpec, config?: AxiosRequestConfig
-  ): Promise<Array<{}>> {
-    return (await this.axios.uploadTable(workspace, table, options, config)).data;
+  public async uploadTable(workspace: string, table: string, options: TableUploadOptionsSpec): Promise<Array<{}>> {
+    return (await this.axios.uploadTable(workspace, table, options)).data;
   }
 
   public async downloadTable(workspace: string, table: string): Promise<any> {
@@ -245,8 +241,8 @@ class MultinetAPI {
     return types;
   }
 
-  public async uploadNetwork(workspace: string, network: string, options: NetworkUploadOptionsSpec, config?: AxiosRequestConfig): Promise<Array<{}>> {
-    return (await this.axios.uploadNetwork(workspace, network, options, config)).data;
+  public async uploadNetwork(workspace: string, network: string, options: NetworkUploadOptionsSpec): Promise<Array<{}>> {
+    return (await this.axios.uploadNetwork(workspace, network, options)).data;
   }
 
   public async createGraph(workspace: string, graph: string, options: CreateGraphOptionsSpec): Promise<CreateGraphOptionsSpec> {

--- a/src/index.ts
+++ b/src/index.ts
@@ -124,7 +124,6 @@ export interface TableMetadata {
 export interface FileUploadOptionsSpec {
   type: UploadType;
   data: File;
-  url: string;
   edgeTable?: boolean;
   key?: string;
   overwrite?: boolean;

--- a/src/index.ts
+++ b/src/index.ts
@@ -243,6 +243,10 @@ class MultinetAPI {
     return types;
   }
 
+  public async uploadNetwork(workspace: string, network: string, options: FileUploadOptionsSpec, config?: AxiosRequestConfig): Promise<Array<{}>> {
+    return (await this.axios.uploadNetwork(workspace, network, options, config)).data;
+  }
+
   public async createGraph(workspace: string, graph: string, options: CreateGraphOptionsSpec): Promise<CreateGraphOptionsSpec> {
     return (await this.axios.createGraph(workspace, graph, options)).data;
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -123,7 +123,9 @@ export interface TableMetadata {
 
 export interface FileUploadOptionsSpec {
   type: UploadType;
-  data: string | File;
+  data: File;
+  url: string;
+  edgeTable?: boolean;
   key?: string;
   overwrite?: boolean;
   columnTypes?: {

--- a/src/index.ts
+++ b/src/index.ts
@@ -82,8 +82,16 @@ export type TableUploadType = 'csv';
 export type GraphUploadType = 'nested_json' | 'newick' | 'd3_json';
 export type UploadType = TableUploadType | GraphUploadType;
 
+export function validTableUploadType(type: string): type is TableUploadType {
+  return type === 'csv';
+}
+
+export function validGraphUploadType(type: string): type is GraphUploadType {
+  return ['nested_json', 'newick', 'd3_json'].includes(type);
+}
+
 export function validUploadType(type: string): type is UploadType {
-  return ['csv', 'nested_json', 'newick', 'd3_json'].includes(type);
+  return validTableUploadType(type) || validGraphUploadType(type);
 }
 
 export type Direction = 'all' | 'incoming' | 'outgoing';

--- a/yarn.lock
+++ b/yarn.lock
@@ -1185,6 +1185,13 @@ diff@^4.0.1:
   resolved "https://registry.yarnpkg.com/diff/-/diff-4.0.2.tgz#60f3aecb89d5fae520c11aa19efc2bb982aade7d"
   integrity sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==
 
+django-s3-file-field@^0.1.2:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/django-s3-file-field/-/django-s3-file-field-0.1.2.tgz#eeee3c4fcc9debca1c07f800d175fd8e559c076f"
+  integrity sha512-zo0YYIZCvH7efYFBKM44VtQLofLCe286dez7HnxB/gUTdbFfV0Zp9lBc+tQ9YVbpyJMLrCaVWvRqR7dkJUAVwg==
+  dependencies:
+    axios "^0.21.1"
+
 domexception@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/domexception/-/domexception-2.0.1.tgz#fb44aefba793e1574b0af6aed2801d057529f304"


### PR DESCRIPTION
Updates the FileUploadOptionsSpec interface to add necessary new parameters (base url and edge table status) then integrates components from the S3FF JS client to make uploading functional.  Also creates a separate uploadNetwork() function, instead of having both tables and networks use uploadTable().

This PR works in conjunction with the s3ff branch of [multinet-client](https://github.com/multinet-app/multinet-client/tree/s3ff)

Should be merged after #42.  Commits pertinent to this PR are: 24b119c, d464a4f and 3ba3acf (all other commits are for changes addressed in #42).
**Edit: Now that #42 is merged, all commits associated with this PR are relevant.**

Closes #40 