### PR TITLE
Ensure compatability with girder4 permission endpoints

### DIFF
--- a/src/axios.ts
+++ b/src/axios.ts
@@ -15,6 +15,7 @@ import {
   Table,
   UserSpec,
   WorkspacePermissionsSpec,
+  WorkspacePermissionRequestSpec,
   Workspace,
 } from './index';
 
@@ -79,13 +80,11 @@ export function multinetAxiosInstance(config: AxiosRequestConfig): MultinetAxios
   };
 
   Proto.getWorkspacePermissions = function(workspace: string): AxiosPromise<WorkspacePermissionsSpec> {
-    return this.get(`workspaces/${workspace}/permissions`);
+    return this.get(`workspaces/${workspace}/permissions/`);
   };
 
-  Proto.setWorkspacePermissions = function(workspace: string, permissions: WorkspacePermissionsSpec): AxiosPromise<WorkspacePermissionsSpec> {
-    return this.put(`workspaces/${workspace}/permissions`, {
-      params: permissions,
-    });
+  Proto.setWorkspacePermissions = function(workspace: string, permissions: WorkspacePermissionRequestSpec): AxiosPromise<WorkspacePermissionRequestSpec> {
+    return this.put(`workspaces/${workspace}/permissions/`, permissions)
   };
 
   Proto.searchUsers = function(username: string): AxiosPromise<UserSpec[]> {

--- a/src/axios.ts
+++ b/src/axios.ts
@@ -15,7 +15,6 @@ import {
   Table,
   UserSpec,
   WorkspacePermissionsSpec,
-  WorkspacePermissionRequestSpec,
   Workspace,
 } from './index';
 
@@ -83,7 +82,7 @@ export function multinetAxiosInstance(config: AxiosRequestConfig): MultinetAxios
     return this.get(`workspaces/${workspace}/permissions/`);
   };
 
-  Proto.setWorkspacePermissions = function(workspace: string, permissions: WorkspacePermissionRequestSpec): AxiosPromise<WorkspacePermissionRequestSpec> {
+  Proto.setWorkspacePermissions = function(workspace: string, permissions: WorkspacePermissionsSpec): AxiosPromise<WorkspacePermissionsSpec> {
     return this.put(`workspaces/${workspace}/permissions/`, permissions)
   };
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -58,24 +58,11 @@ export interface UserSpec {
   id: number;
 }
 
-export interface MinimumUserSpec {
-  username: string;
-}
-
 export interface WorkspacePermissionsSpec {
   owner: UserSpec;
   maintainers: UserSpec[];
   writers: UserSpec[];
   readers: UserSpec[];
-  public: boolean;
-}
-
-export interface WorkspacePermissionRequestSpec {
-  /* In order to set permissions, the API only needs usernames */
-  owner: MinimumUserSpec;
-  maintainers: MinimumUserSpec[];
-  writers: MinimumUserSpec[];
-  readers: MinimumUserSpec[];
   public: boolean;
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -53,11 +53,13 @@ export interface UserSpec {
   username: string;
   first_name: string;
   last_name: string;
-  admin: boolean;
-  name: string;
-  picture: string;
+  is_superuser: boolean;
   email: string;
-  sub: string;
+  id: number;
+}
+
+export interface MinimumUserSpec {
+  username: string;
 }
 
 export interface WorkspacePermissionsSpec {
@@ -65,6 +67,15 @@ export interface WorkspacePermissionsSpec {
   maintainers: UserSpec[];
   writers: UserSpec[];
   readers: UserSpec[];
+  public: boolean;
+}
+
+export interface WorkspacePermissionRequestSpec {
+  /* In order to set permissions, the API only needs usernames */
+  owner: MinimumUserSpec;
+  maintainers: MinimumUserSpec[];
+  writers: MinimumUserSpec[];
+  readers: MinimumUserSpec[];
   public: boolean;
 }
 


### PR DESCRIPTION
This pull request updates `multinetjs` to be compatible with the new Girder4 back end API. Specifically, interfaces defined in here now comply with the Django data model for users and permissions, and the `axios` calls to permission endpoints have been updated for compatibility.

Changes include:

1. Update to `UserSpec` interface
2. Update to `getWorkspacePermissions` and `setWorkspacePermissions` functions