### PR TITLE
 Refactor multinetjs to work with new workspace renaming endpoint

### DIFF
--- a/src/axios.ts
+++ b/src/axios.ts
@@ -52,7 +52,7 @@ export interface MultinetAxiosInstance extends AxiosInstance {
   edges(workspace: string, graph: string, options: EdgesOptionsSpec): AxiosPromise<Paginated<EdgesSpec>>;
   createWorkspace(workspace: string): AxiosPromise<string>;
   deleteWorkspace(workspace: string): AxiosPromise<string>;
-  renameWorkspace(workspace: string, name: string): AxiosPromise<any>;
+  renameWorkspace(workspace: string, name: string): AxiosPromise<Workspace>;
   uploadTable(workspace: string, table: string, options: TableUploadOptionsSpec, config?: AxiosRequestConfig): AxiosPromise<Array<{}>>;
   downloadTable(workspace: string, table: string): AxiosPromise<any>;
   deleteTable(workspace: string, table: string): AxiosPromise<string>;
@@ -139,7 +139,7 @@ export function multinetAxiosInstance(config: AxiosRequestConfig): MultinetAxios
     return this.delete(`/workspaces/${workspace}`);
   };
 
-  Proto.renameWorkspace = function(workspace: string, name: string): AxiosPromise<any> {
+  Proto.renameWorkspace = function(workspace: string, name: string): AxiosPromise<Workspace> {
     return this.put(`workspaces/${workspace}/`, {
       name,
     });

--- a/src/axios.ts
+++ b/src/axios.ts
@@ -140,10 +140,8 @@ export function multinetAxiosInstance(config: AxiosRequestConfig): MultinetAxios
   };
 
   Proto.renameWorkspace = function(workspace: string, name: string): AxiosPromise<any> {
-    return this.put(`workspaces/${workspace}/name`, null, {
-      params: {
-        name,
-      },
+    return this.put(`workspaces/${workspace}/`, {
+      name,
     });
   };
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -216,7 +216,7 @@ class MultinetAPI {
     return (await this.axios.deleteWorkspace(workspace)).data;
   }
 
-  public async renameWorkspace(workspace: string, name: string): Promise<any> {
+  public async renameWorkspace(workspace: string, name: string): Promise<Workspace> {
     return (await this.axios.renameWorkspace(workspace, name)).data;
   }
 


### PR DESCRIPTION
Makes necessary changes to the renameWorkspace call to make it work with the new endpoint, including changing the url, passing the new name directly rather than as a parameter and updating its return type to be the Workspace interface.

Works in conjunction with the rename-workspace branches of [multinet-client](https://github.com/multinet-app/multinet-client/tree/rename-workspace) and [multinet-api](https://github.com/multinet-app/multinet-api/tree/rename-workspace).