### PR TITLE
Replace all use of 'graph(s)' with 'network(s)' for consistency

### DIFF
--- a/src/axios.ts
+++ b/src/axios.ts
@@ -2,16 +2,16 @@ import axios, { AxiosInstance, AxiosPromise, AxiosRequestConfig, AxiosResponse }
 import S3FileFieldClient, { S3FileFieldProgress, S3FileFieldProgressState } from 'django-s3-file-field';
 
 import {
-  CreateGraphOptionsSpec,
+  CreateNetworkOptionsSpec,
   TableMetadata,
   TableUploadOptionsSpec,
   NetworkUploadOptionsSpec,
   EdgesSpec,
   EdgesOptionsSpec,
-  Graph,
+  Network,
   OffsetLimitSpec,
   Paginated,
-  GraphSpec,
+  NetworkSpec,
   TableRow,
   TablesOptionsSpec,
   Table,
@@ -46,10 +46,10 @@ export interface MultinetAxiosInstance extends AxiosInstance {
   searchUsers(username: string): AxiosPromise<UserSpec[]>;
   tables(workspace: string, options: TablesOptionsSpec): AxiosPromise<Paginated<Table>>;
   table(workspace: string, table: string, options: OffsetLimitSpec): AxiosPromise<Paginated<TableRow>>;
-  graphs(workspace: string): AxiosPromise<Paginated<Graph>>;
-  graph(workspace: string, graph: string): AxiosPromise<GraphSpec>;
-  nodes(workspace: string, graph: string, options: OffsetLimitSpec): AxiosPromise<Paginated<TableRow>>;
-  edges(workspace: string, graph: string, options: EdgesOptionsSpec): AxiosPromise<Paginated<EdgesSpec>>;
+  networks(workspace: string): AxiosPromise<Paginated<Network>>;
+  network(workspace: string, network: string): AxiosPromise<NetworkSpec>;
+  nodes(workspace: string, network: string, options: OffsetLimitSpec): AxiosPromise<Paginated<TableRow>>;
+  edges(workspace: string, network: string, options: EdgesOptionsSpec): AxiosPromise<Paginated<EdgesSpec>>;
   createWorkspace(workspace: string): AxiosPromise<string>;
   deleteWorkspace(workspace: string): AxiosPromise<string>;
   renameWorkspace(workspace: string, name: string): AxiosPromise<any>;
@@ -58,11 +58,11 @@ export interface MultinetAxiosInstance extends AxiosInstance {
   deleteTable(workspace: string, table: string): AxiosPromise<string>;
   tableMetadata(workspace: string, table: string): AxiosPromise<TableMetadata>;
   uploadNetwork(workspace: string, network: string, options: NetworkUploadOptionsSpec, config?: AxiosRequestConfig): AxiosPromise<Array<{}>>;
-  createGraph(workspace: string, graph: string, options: CreateGraphOptionsSpec): AxiosPromise<CreateGraphOptionsSpec>;
-  deleteGraph(workspace: string, graph: string): AxiosPromise<string>;
+  createNetwork(workspace: string, network: string, options: CreateNetworkOptionsSpec): AxiosPromise<CreateNetworkOptionsSpec>;
+  deleteNetwork(workspace: string, network: string): AxiosPromise<string>;
   aql(workspace: string, query: string): AxiosPromise<any[]>;
   createAQLTable(workspace: string, table: string, query: string): AxiosPromise<any[]>;
-  downloadGraph(workspace: string, graph: string): AxiosPromise<any>;
+  downloadNetwork(workspace: string, network: string): AxiosPromise<any>;
 }
 
 export function multinetAxiosInstance(config: AxiosRequestConfig): MultinetAxiosInstance {
@@ -109,22 +109,22 @@ export function multinetAxiosInstance(config: AxiosRequestConfig): MultinetAxios
     });
   };
 
-  Proto.graphs = function(workspace: string): AxiosPromise<Paginated<Graph>> {
+  Proto.networks = function(workspace: string): AxiosPromise<Paginated<Network>> {
     return this.get(`workspaces/${workspace}/networks`);
   };
 
-  Proto.graph = function(workspace: string, graph: string): AxiosPromise<GraphSpec> {
-    return this.get(`workspaces/${workspace}/networks/${graph}`);
+  Proto.network = function(workspace: string, network: string): AxiosPromise<NetworkSpec> {
+    return this.get(`workspaces/${workspace}/networks/${network}`);
   };
 
-  Proto.nodes = function(workspace: string, graph: string, options: OffsetLimitSpec = {}): AxiosPromise<Paginated<TableRow>> {
-    return this.get(`workspaces/${workspace}/networks/${graph}/nodes`, {
+  Proto.nodes = function(workspace: string, network: string, options: OffsetLimitSpec = {}): AxiosPromise<Paginated<TableRow>> {
+    return this.get(`workspaces/${workspace}/networks/${network}/nodes`, {
       params: options,
     });
   };
 
-  Proto.edges = function(workspace: string, graph: string, options: EdgesOptionsSpec = {}): AxiosPromise<Paginated<EdgesSpec>> {
-    return this.get(`workspaces/${workspace}/networks/${graph}/edges`, {
+  Proto.edges = function(workspace: string, network: string, options: EdgesOptionsSpec = {}): AxiosPromise<Paginated<EdgesSpec>> {
+    return this.get(`workspaces/${workspace}/networks/${network}/edges`, {
       params: options,
     });
   };
@@ -191,15 +191,15 @@ export function multinetAxiosInstance(config: AxiosRequestConfig): MultinetAxios
     });
   };
 
-  Proto.createGraph = function(workspace: string, graph: string, options: CreateGraphOptionsSpec): AxiosPromise<CreateGraphOptionsSpec> {
+  Proto.createNetwork = function(workspace: string, network: string, options: CreateNetworkOptionsSpec): AxiosPromise<CreateNetworkOptionsSpec> {
     return this.post(`/workspaces/${workspace}/networks/`, {
-      name: graph,
+      name: network,
       edge_table: options.edgeTable,
     });
   };
 
-  Proto.deleteGraph = function(workspace: string, graph: string): AxiosPromise<string> {
-    return this.delete(`/workspaces/${workspace}/networks/${graph}`);
+  Proto.deleteNetwork = function(workspace: string, network: string): AxiosPromise<string> {
+    return this.delete(`/workspaces/${workspace}/networks/${network}`);
   };
 
   Proto.aql = function(workspace: string, query: string): AxiosPromise<any[]> {
@@ -221,8 +221,8 @@ export function multinetAxiosInstance(config: AxiosRequestConfig): MultinetAxios
     });
   };
 
-  Proto.downloadGraph = function(workspace: string, graph: string): AxiosPromise<any> {
-    return this.get(`/workspaces/${workspace}/graphs/${graph}/download`);
+  Proto.downloadNetwork = function(workspace: string, network: string): AxiosPromise<any> {
+    return this.get(`/workspaces/${workspace}/networks/${network}/download`);
   };
 
   return axiosInstance as MultinetAxiosInstance;

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,14 +22,14 @@ export interface TableRow {
   _rev: string;
 }
 
-export interface Graph {
+export interface Network {
   id: number;
   name: string;
   created: string;
   modified: string;
 }
 
-export interface GraphSpec {
+export interface NetworkSpec {
   id: number;
   name: string;
   node_count: number;
@@ -77,19 +77,19 @@ export interface Workspace {
 export type TableType = 'all' | 'node' | 'edge';
 
 export type TableUploadType = 'csv';
-export type GraphUploadType = 'nested_json' | 'newick' | 'd3_json';
-export type UploadType = TableUploadType | GraphUploadType;
+export type NetworkUploadType = 'nested_json' | 'newick' | 'd3_json';
+export type UploadType = TableUploadType | NetworkUploadType;
 
 export function validTableUploadType(type: string): type is TableUploadType {
   return type === 'csv';
 }
 
-export function validGraphUploadType(type: string): type is GraphUploadType {
+export function validNetworkUploadType(type: string): type is NetworkUploadType {
   return ['nested_json', 'newick', 'd3_json'].includes(type);
 }
 
 export function validUploadType(type: string): type is UploadType {
-  return validTableUploadType(type) || validGraphUploadType(type);
+  return validTableUploadType(type) || validNetworkUploadType(type);
 }
 
 export type Direction = 'all' | 'incoming' | 'outgoing';
@@ -135,10 +135,10 @@ export interface TableUploadOptionsSpec {
 
 export interface NetworkUploadOptionsSpec {
   data: File;
-  type: GraphUploadType;
+  type: NetworkUploadType;
 }
 
-export interface CreateGraphOptionsSpec {
+export interface CreateNetworkOptionsSpec {
   edgeTable: string;
 }
 
@@ -192,20 +192,20 @@ class MultinetAPI {
     return (await this.axios.table(workspace, table, options)).data;
   }
 
-  public async graphs(workspace: string): Promise<Paginated<Graph>> {
-    return (await this.axios.graphs(workspace)).data;
+  public async networks(workspace: string): Promise<Paginated<Network>> {
+    return (await this.axios.networks(workspace)).data;
   }
 
-  public async graph(workspace: string, graph: string): Promise<GraphSpec> {
-    return (await this.axios.graph(workspace, graph)).data;
+  public async network(workspace: string, network: string): Promise<NetworkSpec> {
+    return (await this.axios.network(workspace, network)).data;
   }
 
-  public async nodes(workspace: string, graph: string, options: OffsetLimitSpec = {}): Promise<Paginated<TableRow>> {
-    return (await this.axios.nodes(workspace, graph, options)).data;
+  public async nodes(workspace: string, network: string, options: OffsetLimitSpec = {}): Promise<Paginated<TableRow>> {
+    return (await this.axios.nodes(workspace, network, options)).data;
   }
 
-  public async edges(workspace: string, graph: string, options: EdgesOptionsSpec = {}): Promise<Paginated<EdgesSpec>> {
-    return (await this.axios.edges(workspace, graph, options)).data;
+  public async edges(workspace: string, network: string, options: EdgesOptionsSpec = {}): Promise<Paginated<EdgesSpec>> {
+    return (await this.axios.edges(workspace, network, options)).data;
   }
 
   public async createWorkspace(workspace: string): Promise<string> {
@@ -250,12 +250,12 @@ class MultinetAPI {
     return (await this.axios.uploadNetwork(workspace, network, options)).data;
   }
 
-  public async createGraph(workspace: string, graph: string, options: CreateGraphOptionsSpec): Promise<CreateGraphOptionsSpec> {
-    return (await this.axios.createGraph(workspace, graph, options)).data;
+  public async createNetwork(workspace: string, network: string, options: CreateNetworkOptionsSpec): Promise<CreateNetworkOptionsSpec> {
+    return (await this.axios.createNetwork(workspace, network, options)).data;
   }
 
-  public async deleteGraph(workspace: string, graph: string): Promise<string> {
-    return (await this.axios.deleteGraph(workspace, graph)).data;
+  public async deleteNetwork(workspace: string, network: string): Promise<string> {
+    return (await this.axios.deleteNetwork(workspace, network)).data;
   }
 
   public async aql(workspace: string, query: string): Promise<any[]> {
@@ -266,8 +266,8 @@ class MultinetAPI {
     return (await this.axios.createAQLTable(workspace, table, query)).data;
   }
 
-  public async downloadGraph(workspace: string, graph: string): Promise<any> {
-    return (await this.axios.downloadGraph(workspace, graph)).data;
+  public async downloadNetwork(workspace: string, network: string): Promise<any> {
+    return (await this.axios.downloadNetwork(workspace, network)).data;
   }
 }
 


### PR DESCRIPTION
Replaces all use of graph(s) with network(s) to maintain continuity across the frontend.

Works in conjunction with the graph-to-network branch of [multinet-client](https://github.com/multinet-app/multinet-client/tree/graph-to-network).

Closes #34