### PR TITLE
Add function to retrieve current user's workspace permission

### DIFF
--- a/src/axios.ts
+++ b/src/axios.ts
@@ -15,6 +15,7 @@ import {
   TableRow,
   TablesOptionsSpec,
   Table,
+  UserPermissionSpec,
   UserSpec,
   WorkspacePermissionsSpec,
   Workspace,
@@ -42,6 +43,7 @@ export interface MultinetAxiosInstance extends AxiosInstance {
   userInfo(): AxiosPromise<UserSpec | null>;
   workspaces(): AxiosPromise<Paginated<Workspace>>;
   getWorkspacePermissions(workspace: string): AxiosPromise<WorkspacePermissionsSpec>;
+  getCurrentUserWorkspacePermissions(workspace: string): AxiosPromise<UserPermissionSpec>
   setWorkspacePermissions(workspace: string, permissions: WorkspacePermissionsSpec): AxiosPromise<WorkspacePermissionsSpec>;
   searchUsers(username: string): AxiosPromise<UserSpec[]>;
   tables(workspace: string, options: TablesOptionsSpec): AxiosPromise<Paginated<Table>>;
@@ -84,6 +86,10 @@ export function multinetAxiosInstance(config: AxiosRequestConfig): MultinetAxios
   Proto.getWorkspacePermissions = function(workspace: string): AxiosPromise<WorkspacePermissionsSpec> {
     return this.get(`workspaces/${workspace}/permissions/`);
   };
+
+  Proto.getCurrentUserWorkspacePermissions = function(workspace: string): AxiosPromise<UserPermissionSpec> {
+    return this.get(`workspaces/${workspace}/permissions/me/`);
+  }
 
   Proto.setWorkspacePermissions = function(workspace: string, permissions: WorkspacePermissionsSpec): AxiosPromise<WorkspacePermissionsSpec> {
     return this.put(`workspaces/${workspace}/permissions/`, permissions)
@@ -153,7 +159,7 @@ export function multinetAxiosInstance(config: AxiosRequestConfig): MultinetAxios
       baseUrl: `${this.defaults.baseURL}/s3-upload/`,
       apiConfig: this.defaults,
     });
-    
+
     const fieldValue = await s3ffClient.uploadFile(data, 'api.Upload.blob');
 
     return this.post(`/workspaces/${workspace}/uploads/csv/`, {

--- a/src/axios.ts
+++ b/src/axios.ts
@@ -43,7 +43,7 @@ export interface MultinetAxiosInstance extends AxiosInstance {
   userInfo(): AxiosPromise<UserSpec | null>;
   workspaces(): AxiosPromise<Paginated<Workspace>>;
   getWorkspacePermissions(workspace: string): AxiosPromise<WorkspacePermissionsSpec>;
-  getCurrentUserWorkspacePermissions(workspace: string): AxiosPromise<SingleUserWorkspacePermissionSpec>
+  getCurrentUserWorkspacePermissions(workspace: string): AxiosPromise<SingleUserWorkspacePermissionSpec>;
   setWorkspacePermissions(workspace: string, permissions: WorkspacePermissionsSpec): AxiosPromise<WorkspacePermissionsSpec>;
   searchUsers(username: string): AxiosPromise<UserSpec[]>;
   tables(workspace: string, options: TablesOptionsSpec): AxiosPromise<Paginated<Table>>;
@@ -89,7 +89,7 @@ export function multinetAxiosInstance(config: AxiosRequestConfig): MultinetAxios
 
   Proto.getCurrentUserWorkspacePermissions = function(workspace: string): AxiosPromise<SingleUserWorkspacePermissionSpec> {
     return this.get(`workspaces/${workspace}/permissions/me/`);
-  }
+  };
 
   Proto.setWorkspacePermissions = function(workspace: string, permissions: WorkspacePermissionsSpec): AxiosPromise<WorkspacePermissionsSpec> {
     return this.put(`workspaces/${workspace}/permissions/`, permissions)

--- a/src/axios.ts
+++ b/src/axios.ts
@@ -15,7 +15,7 @@ import {
   TableRow,
   TablesOptionsSpec,
   Table,
-  UserPermissionSpec,
+  SingleUserWorkspacePermissionSpec,
   UserSpec,
   WorkspacePermissionsSpec,
   Workspace,
@@ -43,7 +43,7 @@ export interface MultinetAxiosInstance extends AxiosInstance {
   userInfo(): AxiosPromise<UserSpec | null>;
   workspaces(): AxiosPromise<Paginated<Workspace>>;
   getWorkspacePermissions(workspace: string): AxiosPromise<WorkspacePermissionsSpec>;
-  getCurrentUserWorkspacePermissions(workspace: string): AxiosPromise<UserPermissionSpec>
+  getCurrentUserWorkspacePermissions(workspace: string): AxiosPromise<SingleUserWorkspacePermissionSpec>
   setWorkspacePermissions(workspace: string, permissions: WorkspacePermissionsSpec): AxiosPromise<WorkspacePermissionsSpec>;
   searchUsers(username: string): AxiosPromise<UserSpec[]>;
   tables(workspace: string, options: TablesOptionsSpec): AxiosPromise<Paginated<Table>>;
@@ -87,7 +87,7 @@ export function multinetAxiosInstance(config: AxiosRequestConfig): MultinetAxios
     return this.get(`workspaces/${workspace}/permissions/`);
   };
 
-  Proto.getCurrentUserWorkspacePermissions = function(workspace: string): AxiosPromise<UserPermissionSpec> {
+  Proto.getCurrentUserWorkspacePermissions = function(workspace: string): AxiosPromise<SingleUserWorkspacePermissionSpec> {
     return this.get(`workspaces/${workspace}/permissions/me/`);
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -56,6 +56,12 @@ export interface UserSpec {
   id: number;
 }
 
+export interface UserPermissionSpec {
+  username: string;
+  workspace: string;
+  permission: string;
+}
+
 export interface WorkspacePermissionsSpec {
   owner: UserSpec;
   maintainers: UserSpec[];

--- a/src/index.ts
+++ b/src/index.ts
@@ -59,7 +59,7 @@ export interface UserSpec {
 export interface SingleUserWorkspacePermissionSpec {
   username: string;
   workspace: string;
-  permission: string;
+  permission: string | null;
 }
 
 export interface WorkspacePermissionsSpec {

--- a/src/index.ts
+++ b/src/index.ts
@@ -56,7 +56,7 @@ export interface UserSpec {
   id: number;
 }
 
-export interface UserPermissionSpec {
+export interface SingleUserWorkspacePermissionSpec {
   username: string;
   workspace: string;
   permission: string;
@@ -176,7 +176,7 @@ class MultinetAPI {
     return (await this.axios.getWorkspacePermissions(workspace)).data;
   }
 
-  public async getCurrentUserWorkspacePermissions(workspace: string): Promise<UserPermissionSpec> {
+  public async getCurrentUserWorkspacePermissions(workspace: string): Promise<SingleUserWorkspacePermissionSpec> {
     if (!workspace) {
       throw new Error('argument "workspace" must not be empty');
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -176,6 +176,14 @@ class MultinetAPI {
     return (await this.axios.getWorkspacePermissions(workspace)).data;
   }
 
+  public async getCurrentUserWorkspacePermissions(workspace: string): Promise<UserPermissionSpec> {
+    if (!workspace) {
+      throw new Error('argument "workspace" must not be empty');
+    }
+
+    return (await this.axios.getCurrentUserWorkspacePermissions(workspace)).data;
+  }
+
   public async setWorkspacePermissions(
     workspace: string, permissions: WorkspacePermissionsSpec
   ): Promise<WorkspacePermissionsSpec> {


### PR DESCRIPTION
This PR is dependent on [this multinet-api PR](https://github.com/multinet-app/multinet-api/pull/67). See that PR for specific details regarding the new API endpoint.

This PR works in conjunction with the above API PR to allow for retrieval of the permission of the currently logged in user for a given workspace.

Changes:

1. New `SingleUserWorkspacePermissionSpec` to describe the server's response for a `GET /api/workspaces/{workspace}/permissions/me` request
2. New functions to allow our custom axios instance to make relevant requests