### PR TITLE
Separate permission into numeric and string representation

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -59,7 +59,8 @@ export interface UserSpec {
 export interface SingleUserWorkspacePermissionSpec {
   username: string;
   workspace: string;
-  permission: string | null;
+  permission: number | null;
+  permission_label: string | null;
 }
 
 export interface WorkspacePermissionsSpec {


### PR DESCRIPTION
This PR modifies the `SingleUserWorkspacePermissionSpec` interface to separate a user's permission into a human readable string, `permission_label`, and a numeric representation, the `permission`. These changes match changes made to the relevant API endpoint in [this PR](https://github.com/multinet-app/multinet-api/pull/68).