### PR TITLE
Add network tables endpoints

### DIFF
--- a/src/axios.ts
+++ b/src/axios.ts
@@ -15,6 +15,7 @@ import {
   TableRow,
   TablesOptionsSpec,
   Table,
+  TableType,
   SingleUserWorkspacePermissionSpec,
   UserSpec,
   WorkspacePermissionsSpec,
@@ -52,6 +53,7 @@ export interface MultinetAxiosInstance extends AxiosInstance {
   network(workspace: string, network: string): AxiosPromise<NetworkSpec>;
   nodes(workspace: string, network: string, options: OffsetLimitSpec): AxiosPromise<Paginated<TableRow>>;
   edges(workspace: string, network: string, options: EdgesOptionsSpec): AxiosPromise<Paginated<EdgesSpec>>;
+  networkTables(workspace: string, network: string, type: TableType): AxiosPromise<Table[]>
   createWorkspace(workspace: string): AxiosPromise<string>;
   deleteWorkspace(workspace: string): AxiosPromise<string>;
   renameWorkspace(workspace: string, name: string): AxiosPromise<Workspace>;
@@ -134,6 +136,10 @@ export function multinetAxiosInstance(config: AxiosRequestConfig): MultinetAxios
       params: options,
     });
   };
+
+  Proto.networkTables = function(workspace: string, network: string, type: TableType = 'all'): AxiosPromise<Table[]> {
+    return this.get(`workspaces/${workspace}/networks/${network}/tables/`, { params: { type: type } });
+  }
 
   Proto.createWorkspace = function(workspace: string): AxiosPromise<string> {
     return this.post(`/workspaces/`, {

--- a/src/axios.ts
+++ b/src/axios.ts
@@ -53,7 +53,7 @@ export interface MultinetAxiosInstance extends AxiosInstance {
   network(workspace: string, network: string): AxiosPromise<NetworkSpec>;
   nodes(workspace: string, network: string, options: OffsetLimitSpec): AxiosPromise<Paginated<TableRow>>;
   edges(workspace: string, network: string, options: EdgesOptionsSpec): AxiosPromise<Paginated<EdgesSpec>>;
-  networkTables(workspace: string, network: string, type: TableType): AxiosPromise<Table[]>
+  networkTables(workspace: string, network: string, type: TableType): AxiosPromise<Table[]>;
   createWorkspace(workspace: string): AxiosPromise<string>;
   deleteWorkspace(workspace: string): AxiosPromise<string>;
   renameWorkspace(workspace: string, name: string): AxiosPromise<Workspace>;
@@ -138,8 +138,8 @@ export function multinetAxiosInstance(config: AxiosRequestConfig): MultinetAxios
   };
 
   Proto.networkTables = function(workspace: string, network: string, type: TableType = 'all'): AxiosPromise<Table[]> {
-    return this.get(`workspaces/${workspace}/networks/${network}/tables/`, { params: { type: type } });
-  }
+    return this.get(`workspaces/${workspace}/networks/${network}/tables/`, { params: {type} });
+  };
 
   Proto.createWorkspace = function(workspace: string): AxiosPromise<string> {
     return this.post(`/workspaces/`, {

--- a/src/index.ts
+++ b/src/index.ts
@@ -223,6 +223,10 @@ class MultinetAPI {
     return (await this.axios.edges(workspace, network, options)).data;
   }
 
+  public async networkTables(workspace: string, network: string, type: TableType = 'all'): Promise<Table[]> {
+    return (await this.axios.networkTables(workspace, network, type)).data;
+  }
+
   public async createWorkspace(workspace: string): Promise<string> {
     return (await this.axios.createWorkspace(workspace)).data;
   }


### PR DESCRIPTION
This PR adds a function to our custom `axios` object to query the `GET /api/workspaces/{workspace}/networks/{network}/tables/` endpoint. By default it returns all tables associated with a network, but the function accepts a parameter, `type` to retrieve only node or edge tables.