### PR TITLE
Update AQL endpoint for girder4 API

### DIFF
--- a/src/axios.ts
+++ b/src/axios.ts
@@ -207,7 +207,7 @@ export function multinetAxiosInstance(config: AxiosRequestConfig): MultinetAxios
   };
 
   Proto.aql = function(workspace: string, query: string): AxiosPromise<any[]> {
-    return this.get(`/workspaces/${workspace}/aql`, { params: { query: query } });
+    return this.get(`/workspaces/${workspace}/aql`, { params: {query} });
   };
 
   Proto.createAQLTable = function(workspace: string, table: string, query: string): AxiosPromise<any[]> {

--- a/src/axios.ts
+++ b/src/axios.ts
@@ -207,7 +207,7 @@ export function multinetAxiosInstance(config: AxiosRequestConfig): MultinetAxios
   };
 
   Proto.aql = function(workspace: string, query: string): AxiosPromise<any[]> {
-    return this.get(`/workspaces/${workspace}/aql`, {params: {query: query}});
+    return this.get(`/workspaces/${workspace}/aql`, { params: { query: query } });
   };
 
   Proto.createAQLTable = function(workspace: string, table: string, query: string): AxiosPromise<any[]> {

--- a/src/axios.ts
+++ b/src/axios.ts
@@ -207,11 +207,7 @@ export function multinetAxiosInstance(config: AxiosRequestConfig): MultinetAxios
   };
 
   Proto.aql = function(workspace: string, query: string): AxiosPromise<any[]> {
-    return this.post(`/workspaces/${workspace}/aql`, query, {
-      headers: {
-        'Content-Type': 'text/plain',
-      },
-    });
+    return this.get(`/workspaces/${workspace}/aql`, {params: {query: query}});
   };
 
   Proto.createAQLTable = function(workspace: string, table: string, query: string): AxiosPromise<any[]> {


### PR DESCRIPTION
This PR updates the `/api/workspaces/{workspace}/aql/` endpoint to use `GET` instead of `POST`, since queries executed via this endpoint are non-mutating. This change ensures compatibility between `multinetjs` and the Django version of the multinet API.