### PR TITLE
Add column types helpers in place of table metadata

### DIFF
--- a/src/axios.ts
+++ b/src/axios.ts
@@ -3,7 +3,7 @@ import S3FileFieldClient, { S3FileFieldProgress, S3FileFieldProgressState } from
 
 import {
   CreateNetworkOptionsSpec,
-  TableMetadata,
+  ColumnTypes,
   TableUploadOptionsSpec,
   NetworkUploadOptionsSpec,
   EdgesSpec,
@@ -60,7 +60,7 @@ export interface MultinetAxiosInstance extends AxiosInstance {
   uploadTable(workspace: string, table: string, options: TableUploadOptionsSpec, config?: AxiosRequestConfig): AxiosPromise<Array<{}>>;
   downloadTable(workspace: string, table: string): AxiosPromise<any>;
   deleteTable(workspace: string, table: string): AxiosPromise<string>;
-  tableMetadata(workspace: string, table: string): AxiosPromise<TableMetadata>;
+  columnTypes(workspace: string, table: string): AxiosPromise<ColumnTypes>;
   uploadNetwork(workspace: string, network: string, options: NetworkUploadOptionsSpec, config?: AxiosRequestConfig): AxiosPromise<Array<{}>>;
   createNetwork(workspace: string, network: string, options: CreateNetworkOptionsSpec): AxiosPromise<CreateNetworkOptionsSpec>;
   deleteNetwork(workspace: string, network: string): AxiosPromise<string>;
@@ -182,8 +182,8 @@ export function multinetAxiosInstance(config: AxiosRequestConfig): MultinetAxios
     return this.delete(`/workspaces/${workspace}/tables/${table}`);
   };
 
-  Proto.tableMetadata = function(workspace: string, table: string): AxiosPromise<TableMetadata> {
-    return this.get(`/workspaces/${workspace}/tables/${table}/metadata`);
+  Proto.columnTypes = function(workspace: string, table: string): AxiosPromise<ColumnTypes> {
+    return this.get(`/workspaces/${workspace}/tables/${table}/annotations`);
   };
 
   Proto.uploadNetwork = async function(workspace: string, network: string, options: NetworkUploadOptionsSpec): Promise<AxiosResponse<Array<{}>>> {

--- a/src/index.ts
+++ b/src/index.ts
@@ -116,20 +116,8 @@ export type EdgesOptionsSpec = OffsetLimitSpec & {
 
 export type ColumnType = 'number' | 'label' | 'category' | 'date' | 'boolean';
 
-export interface ColumnTypesEntry {
-  key: string;
-  type: ColumnType;
-}
-
 export interface ColumnTypes {
   [key: string]: ColumnType;
-}
-
-export interface TableMetadata {
-  item_id: string;
-  table: {
-    columns: ColumnTypesEntry[];
-  };
 }
 
 export interface TableUploadOptionsSpec {
@@ -251,17 +239,8 @@ class MultinetAPI {
     return (await this.axios.deleteTable(workspace, table)).data;
   }
 
-  public async tableMetadata(workspace: string, table: string): Promise<TableMetadata> {
-    return (await this.axios.tableMetadata(workspace, table)).data;
-  }
-
-  public async tableColumnTypes(workspace: string, table: string): Promise<ColumnTypes> {
-    const metadata = await this.tableMetadata(workspace, table);
-
-    const types: ColumnTypes = {};
-    metadata.table.columns.forEach((entry) => {
-      types[entry.key] = entry.type;
-    });
+  public async columnTypes(workspace: string, table: string): Promise<ColumnTypes> {
+    const types = (await this.axios.columnTypes(workspace, table)).data;
     return types;
   }
 


### PR DESCRIPTION
Depends on https://github.com/multinet-app/multinet-api/pull/84

Adds multinetjs wrapper for the new endpoints in the above PR. I removed everything related to `TableMetadata` since we're no longer using it