### PR TITLE
Add route to get upload status

### DIFF
--- a/src/axios.ts
+++ b/src/axios.ts
@@ -67,6 +67,7 @@ export interface MultinetAxiosInstance extends AxiosInstance {
   aql(workspace: string, query: string): AxiosPromise<any[]>;
   createAQLTable(workspace: string, table: string, query: string): AxiosPromise<any[]>;
   downloadNetwork(workspace: string, network: string): AxiosPromise<any>;
+  uploads(workspace: string): AxiosPromise<any>;
 }
 
 export function multinetAxiosInstance(config: AxiosRequestConfig): MultinetAxiosInstance {
@@ -230,6 +231,10 @@ export function multinetAxiosInstance(config: AxiosRequestConfig): MultinetAxios
   Proto.downloadNetwork = function(workspace: string, network: string): AxiosPromise<any> {
     return this.get(`/workspaces/${workspace}/networks/${network}/download`);
   };
+
+  Proto.uploads = function(workspace: string): AxiosPromise<any> {
+    return this.get(`/workspaces/${workspace}/uploads`)
+  }
 
   return axiosInstance as MultinetAxiosInstance;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -267,6 +267,10 @@ class MultinetAPI {
   public async downloadNetwork(workspace: string, network: string): Promise<any> {
     return (await this.axios.downloadNetwork(workspace, network)).data;
   }
+
+  public async uploads(workspace: string): Promise<any> {
+    return (await this.axios.uploads(workspace)).data;
+  }
 }
 
 export function multinetApi(baseURL: string): MultinetAPI {


### PR DESCRIPTION
### Does this PR close any open issues?
The was no issue in this repo for this change.

### Give a longer description of what this PR addresses and why it's needed
This PR adds the ability to query the uploads endpoint using the js library so that we can see when there are incomplete uploads on the main client (and elsewhere if needed).

### Provide pictures/videos of the behavior before and after these changes (optional)
There are no images here. See the main client for a visual implementation

### Are there any additional TODOs before this PR is ready to go?

TODOs:
- [ ] Make a release