### PR TITLE
Add shared login functions

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -279,3 +279,30 @@ class MultinetAPI {
 export function multinetApi(baseURL: string): MultinetAPI {
   return new MultinetAPI(baseURL);
 }
+
+export function writeSharedLoginCookie(token: string, domain?: string) {
+  if (domain === undefined) {
+    domain = window.location.hostname;
+  }
+  document.cookie = `sharedLogin=${token}; Domain=${domain}`;
+}
+
+export function readSharedLoginCookie(): string | null {
+  let value = null;
+
+  const cookie = document.cookie.split('; ')
+    .find((c) => c.startsWith('sharedLogin='));
+
+  if (cookie !== undefined) {
+    value = cookie.split('=')[1];
+  }
+
+  return value;
+}
+
+export function invalidateSharedLoginCookie(domain?: string) {
+  if (domain === undefined) {
+    domain = window.location.hostname;
+  }
+  document.cookie = `sharedLogin=; Domain=${domain}; Max-Age=0`;
+}


### PR DESCRIPTION
This PR adds some utility functions for managing shared login state across different multinet apps. The basic idea is to have one or more apps use the `writeSharedLoginCookie()` function to transmit shared login state to other apps, and have those apps use `readSharedLoginCookie()` to check for a shared login before boostrapping the ordinary oauth-based login flows.

TODOs:
- [ ] perform a release after merge