### PR TITLE
Allow the json table route for uploading

### DIFF
--- a/src/axios.ts
+++ b/src/axios.ts
@@ -159,7 +159,7 @@ export function multinetAxiosInstance(config: AxiosRequestConfig): MultinetAxios
   };
 
   Proto.uploadTable = async function(workspace: string, table: string, options: TableUploadOptionsSpec): Promise<AxiosResponse<Array<{}>>> {
-    const { data, edgeTable, columnTypes, delimiter, quoteChar } = options;
+    const { data, edgeTable, columnTypes, fileType, delimiter, quoteChar } = options;
     const s3ffClient = new S3FileFieldClient({
       baseUrl: `${this.defaults.baseURL}/s3-upload/`,
       apiConfig: this.defaults,
@@ -167,14 +167,27 @@ export function multinetAxiosInstance(config: AxiosRequestConfig): MultinetAxios
 
     const fieldValue = await s3ffClient.uploadFile(data, 'api.Upload.blob');
 
-    return this.post(`workspaces/${workspace}/uploads/csv/`, {
+    console.log('js', fileType);
+
+    if (fileType === 'csv') {
+      return this.post(`workspaces/${workspace}/uploads/csv/`, {
+        field_value: fieldValue.value,
+        edge: edgeTable,
+        table_name: table,
+        columns: columnTypes,
+        delimiter,
+        quotechar: quoteChar,
+      });
+    }
+
+    // else if json
+    return this.post(`workspaces/${workspace}/uploads/json/`, {
       field_value: fieldValue.value,
       edge: edgeTable,
       table_name: table,
       columns: columnTypes,
-      delimiter,
-      quotechar: quoteChar,
     });
+    
   };
 
   Proto.downloadTable = function(workspace: string, table: string): AxiosPromise<any> {

--- a/src/axios.ts
+++ b/src/axios.ts
@@ -167,8 +167,6 @@ export function multinetAxiosInstance(config: AxiosRequestConfig): MultinetAxios
 
     const fieldValue = await s3ffClient.uploadFile(data, 'api.Upload.blob');
 
-    console.log('js', fileType);
-
     if (fileType === 'csv') {
       return this.post(`workspaces/${workspace}/uploads/csv/`, {
         field_value: fieldValue.value,
@@ -187,7 +185,6 @@ export function multinetAxiosInstance(config: AxiosRequestConfig): MultinetAxios
       table_name: table,
       columns: columnTypes,
     });
-    
   };
 
   Proto.downloadTable = function(workspace: string, table: string): AxiosPromise<any> {

--- a/src/index.ts
+++ b/src/index.ts
@@ -126,8 +126,9 @@ export interface TableUploadOptionsSpec {
   columnTypes?: {
     [key: string]: ColumnType;
   };
-  delimiter: string;
-  quoteChar: string;
+  fileType: 'json' | 'csv';
+  delimiter?: string;
+  quoteChar?: string;
 }
 
 export interface NetworkUploadOptionsSpec {


### PR DESCRIPTION
### Does this PR close any open issues?
Closes #

### Give a longer description of what this PR addresses and why it's needed
This allows the client to use the json table upload route to upload a table defined by a JSON table

### Provide pictures/videos of the behavior before and after these changes (optional)


### Are there any additional TODOs before this PR is ready to go?
TODOs:
- [x] Update relevant documentation (multinet-app/multinet-docs#33)
- [ ] Make a release