### PR TITLE
Add multinetjs helpers for state management

### DIFF
--- a/src/axios.ts
+++ b/src/axios.ts
@@ -240,31 +240,31 @@ export function multinetAxiosInstance(config: AxiosRequestConfig): MultinetAxios
       state: {},
       [type]: itemId,
     });
-  }
+  };
 
   Proto.listSessions = function(workspace: string, type: 'network' | 'table'): AxiosPromise<any> {
     return this.get(`workspaces/${workspace}/sessions/${type}/`);
-  }
+  };
 
   Proto.deleteSession = function(workspace: string, sessionId: number, type: 'network' | 'table'): AxiosPromise<any> {
     return this.delete(`workspaces/${workspace}/sessions/${type}/${sessionId}/`);
-  }
+  };
 
   Proto.updateSession = function(workspace: string, sessionId: number, type: 'network' | 'table', state: string): AxiosPromise<any> {
     return this.patch(`workspaces/${workspace}/sessions/${type}/${sessionId}/state/`, {
       state,
     });
-  }
+  };
 
   Proto.renameSession = function(workspace: string, sessionId: number, type: 'network' | 'table', name: string): AxiosPromise<any> {
     return this.patch(`workspaces/${workspace}/sessions/${type}/${sessionId}/name/`, {
       name,
     });
-  }
+  };
 
   Proto.getSession = function(workspace: string, sessionId: number, type: 'network' | 'table'): AxiosPromise<any> {
     return this.get(`workspaces/${workspace}/sessions/${type}/${sessionId}/`);
-  }
+  };
 
   return axiosInstance as MultinetAxiosInstance;
 }

--- a/src/axios.ts
+++ b/src/axios.ts
@@ -66,11 +66,11 @@ export interface MultinetAxiosInstance extends AxiosInstance {
   deleteNetwork(workspace: string, network: string): AxiosPromise<string>;
   aql(workspace: string, payload: AQLQuerySpec): AxiosPromise<any[]>;
   uploads(workspace: string): AxiosPromise<any>;
-  createSession(itemId: number, type: 'network' | 'table', visApp: string, name: string): AxiosPromise<any>;
-  listSessions(type: 'network' | 'table'): AxiosPromise<any>;
-  deleteSession(sessionId: string, type: 'network' | 'table'): Promise<any>;
-  updateSession(sessionId: string, type: 'network' | 'table', state: string): AxiosPromise<any>;
-  getSession(sessionId: string, type: 'network' | 'table'): AxiosPromise<any>;
+  createSession(workspace: string, itemId: number, type: 'network' | 'table', visApp: string, name: string): AxiosPromise<any>;
+  listSessions(workspace: string, type: 'network' | 'table'): AxiosPromise<any>;
+  deleteSession(workspace: string, sessionId: string, type: 'network' | 'table'): Promise<any>;
+  updateSession(workspace: string, sessionId: string, type: 'network' | 'table', state: string): AxiosPromise<any>;
+  getSession(workspace: string, sessionId: string, type: 'network' | 'table'): AxiosPromise<any>;
 }
 
 export function multinetAxiosInstance(config: AxiosRequestConfig): MultinetAxiosInstance {
@@ -232,8 +232,8 @@ export function multinetAxiosInstance(config: AxiosRequestConfig): MultinetAxios
     return this.get(`workspaces/${workspace}/uploads/`);
   };
 
-  Proto.createSession = function(itemId: number, type: 'network' | 'table', visApp: string, name: string): AxiosPromise<any> {
-    return this.post(`sessions/${type}/`, {
+  Proto.createSession = function(workspace: string, itemId: number, type: 'network' | 'table', visApp: string, name: string): AxiosPromise<any> {
+    return this.post(`workspaces/${workspace}/sessions/${type}/`, {
       name,
       visapp: visApp,
       state: {},
@@ -241,22 +241,22 @@ export function multinetAxiosInstance(config: AxiosRequestConfig): MultinetAxios
     });
   }
 
-  Proto.listSessions = function(type: 'network' | 'table'): AxiosPromise<any> {
-    return this.get(`sessions/${type}/`);
+  Proto.listSessions = function(workspace: string, type: 'network' | 'table'): AxiosPromise<any> {
+    return this.get(`workspaces/${workspace}/sessions/${type}/`);
   }
 
-  Proto.deleteSession = function(sessionId: string, type: 'network' | 'table'): AxiosPromise<any> {
-    return this.delete(`sessions/${type}/${sessionId}/`);
+  Proto.deleteSession = function(workspace: string, sessionId: string, type: 'network' | 'table'): AxiosPromise<any> {
+    return this.delete(`workspaces/${workspace}/sessions/${type}/${sessionId}/`);
   }
 
-  Proto.updateSession = function(sessionId: string, type: 'network' | 'table', state: string): AxiosPromise<any> {
-    return this.patch(`sessions/${type}/${sessionId}/state/`, {
+  Proto.updateSession = function(workspace: string, sessionId: string, type: 'network' | 'table', state: string): AxiosPromise<any> {
+    return this.patch(`workspaces/${workspace}/sessions/${type}/${sessionId}/state/`, {
       state,
     });
   }
 
-  Proto.getSession = function(sessionId: string, type: 'network' | 'table'): AxiosPromise<any> {
-    return this.get(`sessions/${type}/${sessionId}`);
+  Proto.getSession = function(workspace: string, sessionId: string, type: 'network' | 'table'): AxiosPromise<any> {
+    return this.get(`workspaces/${workspace}/sessions/${type}/${sessionId}/`);
   }
 
   return axiosInstance as MultinetAxiosInstance;

--- a/src/axios.ts
+++ b/src/axios.ts
@@ -66,6 +66,11 @@ export interface MultinetAxiosInstance extends AxiosInstance {
   deleteNetwork(workspace: string, network: string): AxiosPromise<string>;
   aql(workspace: string, payload: AQLQuerySpec): AxiosPromise<any[]>;
   uploads(workspace: string): AxiosPromise<any>;
+  createSession(itemId: number, type: 'network' | 'table', visApp: string, name: string): AxiosPromise<any>;
+  listSessions(type: 'network' | 'table'): AxiosPromise<any>;
+  deleteSession(sessionId: string, type: 'network' | 'table'): Promise<any>;
+  updateSession(sessionId: string, type: 'network' | 'table', state: string): AxiosPromise<any>;
+  getSession(sessionId: string, type: 'network' | 'table'): AxiosPromise<any>;
 }
 
 export function multinetAxiosInstance(config: AxiosRequestConfig): MultinetAxiosInstance {
@@ -226,6 +231,33 @@ export function multinetAxiosInstance(config: AxiosRequestConfig): MultinetAxios
   Proto.uploads = function(workspace: string): AxiosPromise<any> {
     return this.get(`workspaces/${workspace}/uploads/`);
   };
+
+  Proto.createSession = function(itemId: number, type: 'network' | 'table', visApp: string, name: string): AxiosPromise<any> {
+    return this.post(`sessions/${type}/`, {
+      name,
+      visapp: visApp,
+      state: {},
+      [type]: itemId,
+    });
+  }
+
+  Proto.listSessions = function(type: 'network' | 'table'): AxiosPromise<any> {
+    return this.get(`sessions/${type}/`);
+  }
+
+  Proto.deleteSession = function(sessionId: string, type: 'network' | 'table'): AxiosPromise<any> {
+    return this.delete(`sessions/${type}/${sessionId}/`);
+  }
+
+  Proto.updateSession = function(sessionId: string, type: 'network' | 'table', state: string): AxiosPromise<any> {
+    return this.patch(`sessions/${type}/${sessionId}/state/`, {
+      state,
+    });
+  }
+
+  Proto.getSession = function(sessionId: string, type: 'network' | 'table'): AxiosPromise<any> {
+    return this.get(`sessions/${type}/${sessionId}`);
+  }
 
   return axiosInstance as MultinetAxiosInstance;
 }

--- a/src/axios.ts
+++ b/src/axios.ts
@@ -68,9 +68,10 @@ export interface MultinetAxiosInstance extends AxiosInstance {
   uploads(workspace: string): AxiosPromise<any>;
   createSession(workspace: string, itemId: number, type: 'network' | 'table', visApp: string, name: string): AxiosPromise<any>;
   listSessions(workspace: string, type: 'network' | 'table'): AxiosPromise<any>;
-  deleteSession(workspace: string, sessionId: string, type: 'network' | 'table'): Promise<any>;
-  updateSession(workspace: string, sessionId: string, type: 'network' | 'table', state: string): AxiosPromise<any>;
-  getSession(workspace: string, sessionId: string, type: 'network' | 'table'): AxiosPromise<any>;
+  deleteSession(workspace: string, sessionId: number, type: 'network' | 'table'): Promise<any>;
+  updateSession(workspace: string, sessionId: number, type: 'network' | 'table', state: string): AxiosPromise<any>;
+  renameSession(workspace: string, sessionId: number, type: 'network' | 'table', name: string): AxiosPromise<any>;
+  getSession(workspace: string, sessionId: number, type: 'network' | 'table'): AxiosPromise<any>;
 }
 
 export function multinetAxiosInstance(config: AxiosRequestConfig): MultinetAxiosInstance {
@@ -245,17 +246,23 @@ export function multinetAxiosInstance(config: AxiosRequestConfig): MultinetAxios
     return this.get(`workspaces/${workspace}/sessions/${type}/`);
   }
 
-  Proto.deleteSession = function(workspace: string, sessionId: string, type: 'network' | 'table'): AxiosPromise<any> {
+  Proto.deleteSession = function(workspace: string, sessionId: number, type: 'network' | 'table'): AxiosPromise<any> {
     return this.delete(`workspaces/${workspace}/sessions/${type}/${sessionId}/`);
   }
 
-  Proto.updateSession = function(workspace: string, sessionId: string, type: 'network' | 'table', state: string): AxiosPromise<any> {
+  Proto.updateSession = function(workspace: string, sessionId: number, type: 'network' | 'table', state: string): AxiosPromise<any> {
     return this.patch(`workspaces/${workspace}/sessions/${type}/${sessionId}/state/`, {
       state,
     });
   }
 
-  Proto.getSession = function(workspace: string, sessionId: string, type: 'network' | 'table'): AxiosPromise<any> {
+  Proto.renameSession = function(workspace: string, sessionId: number, type: 'network' | 'table', name: string): AxiosPromise<any> {
+    return this.patch(`workspaces/${workspace}/sessions/${type}/${sessionId}/name/`, {
+      name,
+    });
+  }
+
+  Proto.getSession = function(workspace: string, sessionId: number, type: 'network' | 'table'): AxiosPromise<any> {
     return this.get(`workspaces/${workspace}/sessions/${type}/${sessionId}/`);
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -279,24 +279,24 @@ class MultinetAPI {
     return (await this.axios.uploads(workspace)).data;
   }
 
-  public async createSession(itemId: number, type: 'network' | 'table', visApp: string, name: string): Promise<any> {
-    return (await this.axios.createSession(itemId, type, visApp, name)).data;
+  public async createSession(workspace: string, itemId: number, type: 'network' | 'table', visApp: string, name: string): Promise<any> {
+    return (await this.axios.createSession(workspace, itemId, type, visApp, name)).data;
   }
 
-  public async listSessions(type: 'network' | 'table'): Promise<any> {
-    return (await this.axios.listSessions(type)).data;
+  public async listSessions(workspace: string, type: 'network' | 'table'): Promise<any> {
+    return (await this.axios.listSessions(workspace, type)).data;
   }
 
-  public async deleteSession(sessionId: string, type: 'network' | 'table'): Promise<any> {
-    return (await this.axios.deleteSession(sessionId, type)).data;
+  public async deleteSession(workspace: string, sessionId: string, type: 'network' | 'table'): Promise<any> {
+    return (await this.axios.deleteSession(workspace, sessionId, type)).data;
   }
 
-  public async updateSession(sessionId: string, type: 'network' | 'table', state: string): Promise<any> {
-    return (await this.axios.updateSession(sessionId, type, state)).data;
+  public async updateSession(workspace: string, sessionId: string, type: 'network' | 'table', state: string): Promise<any> {
+    return (await this.axios.updateSession(workspace, sessionId, type, state)).data;
   }
 
-  public async getSession(sessionId: string, type: 'network' | 'table'): Promise<any> {
-    return (await this.axios.getSession(sessionId, type)).data;
+  public async getSession(workspace: string, sessionId: string, type: 'network' | 'table'): Promise<any> {
+    return (await this.axios.getSession(workspace, sessionId, type)).data;
   }
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -145,7 +145,7 @@ export interface AQLQuerySpec {
 }
 
 export type Session = {
-  id: string;
+  id: number;
   created: string;
   modified: string;
   name: string;
@@ -286,15 +286,19 @@ class MultinetAPI {
     return (await this.axios.listSessions(workspace, type)).data;
   }
 
-  public async deleteSession(workspace: string, sessionId: string, type: 'network' | 'table'): Promise<any> {
+  public async deleteSession(workspace: string, sessionId: number, type: 'network' | 'table'): Promise<any> {
     return (await this.axios.deleteSession(workspace, sessionId, type)).data;
   }
 
-  public async updateSession(workspace: string, sessionId: string, type: 'network' | 'table', state: string): Promise<any> {
+  public async updateSession(workspace: string, sessionId: number, type: 'network' | 'table', state: string): Promise<any> {
     return (await this.axios.updateSession(workspace, sessionId, type, state)).data;
   }
 
-  public async getSession(workspace: string, sessionId: string, type: 'network' | 'table'): Promise<any> {
+  public async renameSession(workspace: string, sessionId: number, type: 'network' | 'table', name: string): Promise<any> {
+    return (await this.axios.renameSession(workspace, sessionId, type, name)).data;
+  }
+
+  public async getSession(workspace: string, sessionId: number, type: 'network' | 'table'): Promise<any> {
     return (await this.axios.getSession(workspace, sessionId, type)).data;
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -144,7 +144,7 @@ export interface AQLQuerySpec {
   bind_vars: Record<string, string>;
 }
 
-export type Session = {
+export interface Session {
   id: number;
   created: string;
   modified: string;

--- a/src/index.ts
+++ b/src/index.ts
@@ -151,10 +151,9 @@ export type Session = {
   name: string;
   visapp: string;
   state: object;
-} & (
-  { network: string }
-  | { table: string }
-)
+  network?: number;
+  table?: number;
+}
 
 class MultinetAPI {
   public axios: MultinetAxiosInstance;

--- a/src/index.ts
+++ b/src/index.ts
@@ -144,6 +144,18 @@ export interface AQLQuerySpec {
   bind_vars: Record<string, string>;
 }
 
+export type Session = {
+  id: string;
+  created: string;
+  modified: string;
+  name: string;
+  visapp: string;
+  state: object;
+} & (
+  { network: string }
+  | { table: string }
+)
+
 class MultinetAPI {
   public axios: MultinetAxiosInstance;
 
@@ -265,6 +277,26 @@ class MultinetAPI {
 
   public async uploads(workspace: string): Promise<any> {
     return (await this.axios.uploads(workspace)).data;
+  }
+
+  public async createSession(itemId: number, type: 'network' | 'table', visApp: string, name: string): Promise<any> {
+    return (await this.axios.createSession(itemId, type, visApp, name)).data;
+  }
+
+  public async listSessions(type: 'network' | 'table'): Promise<any> {
+    return (await this.axios.listSessions(type)).data;
+  }
+
+  public async deleteSession(sessionId: string, type: 'network' | 'table'): Promise<any> {
+    return (await this.axios.deleteSession(sessionId, type)).data;
+  }
+
+  public async updateSession(sessionId: string, type: 'network' | 'table', state: string): Promise<any> {
+    return (await this.axios.updateSession(sessionId, type, state)).data;
+  }
+
+  public async getSession(sessionId: string, type: 'network' | 'table'): Promise<any> {
+    return (await this.axios.getSession(sessionId, type)).data;
   }
 }
 


### PR DESCRIPTION
### Does this PR close any open issues?
Depends multinet-app/multinet-api#153
No

### Give a longer description of what this PR addresses and why it's needed
This adds helper functions to handle the conversion from JS to API routes for session creation, listing, updating, and deleting

### Provide pictures/videos of the behavior before and after these changes (optional)
N/A

### Are there any additional TODOs before this PR is ready to go?
TODOs:
- [ ] Release
- [x] Make it so that sessions can be renamed